### PR TITLE
Adds egg name to the rows entry in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ django>=2.0
 ipython
 openpyxl
 psycopg2-binary
-git+https://github.com/turicas/rows.git@develop
+git+https://github.com/turicas/rows.git@develop#egg=rows


### PR DESCRIPTION
This is so pip can properly resolve dependencies[1].
Pipenv, when converting from requirements.txt to a Pipfile, also
complains about the lack of the #egg component in the url when
installing from git.

[1]: https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support