### PR TITLE
Fix line break on template tag

### DIFF
--- a/core/templates/specials/index.html
+++ b/core/templates/specials/index.html
@@ -29,9 +29,10 @@
         href="{% url 'core:dataset-detail' slug='documentos-brasil' %}">busca
         por nome ou documento</a> o visitante poderá acessar um dossiê do
       documento (CPF ou CNPJ), onde serão mostradas ocorrências em vários
-      datasets disponíveis no portal. Exemplo: <a href="{% url
-        'core:special-document-detail' document='75095679000149'
-        %}">Universidade Federal do Paraná</a>.
+      datasets disponíveis no portal. Exemplo:
+      <a href="{% url 'core:special-document-detail' document='75095679000149' %}">
+        Universidade Federal do Paraná
+      </a>.
     </li>
     <li>
       <a href="{% url 'core:special-trace-path' %}">Caminhos nas relações


### PR DESCRIPTION
The line break on the template tag was breaking the template parser.