### PR TITLE
Modifica comportamento da view de documento para tratar o CNPJ pelo prefixo

### DIFF
--- a/core/templates/specials/document-detail.html
+++ b/core/templates/specials/document-detail.html
@@ -14,6 +14,9 @@
 <div class="section">
   <h4>{{ obj.name }}</h4>
 
+  {% if original_document %}
+  <p><strong>Importante:</strong> A busca realizada foi pelo documento {{ original_document }}, mas o mesmo não existe no nosso banco. Estamos apresentando o resultado para uma das empresas da mesma rede empresarial na qual o documento {{ original_document }} pertence.</p>
+  {% endif %}
   <dl>
     <dt> Documento: </dt>
     <dd>{% if encrypted %}{{ obj.document|obfuscate }}{% else %}{{ obj.document }}{% endif %} ({{ obj.document_type|upper }})</b></dd>

--- a/core/templates/specials/document-detail.html
+++ b/core/templates/specials/document-detail.html
@@ -102,6 +102,16 @@
   {% endwith %}
   {% endif %}
 
+  {% if branches.count %}
+  <h4>Matriz e Filiais</h4>
+  <p>
+    Foram identificadas <b>{{ branches.count }}</b> filiais e matriz.
+  </p>
+  {% with table_id='branches' data=branches fields=branches_fields caption='branches-'|add:obj.name  %}
+    {% include 'data-table.html' %}
+  {% endwith %}
+  {% endif %}
+
 </div>
 {% endwith %}{% endlocalize %}{% endblock %}
 

--- a/core/views_special.py
+++ b/core/views_special.py
@@ -73,7 +73,6 @@ def document_detail(request, document):
         except (UnicodeEncodeError, InvalidToken, UnicodeDecodeError):
             raise Http404
     document = document.replace('.', '').replace('-', '').replace('/', '').strip()
-
     cnpj_search = len(document) == 14
     doc_prefix = document[:8]
     branches = Documents.objects.none()
@@ -173,6 +172,7 @@ def document_detail(request, document):
             GastosDiretos.objects.filter(codigo_favorecido=obj.document)\
                                  .order_by('-data_pagamento')
 
+    original_document = request.GET.get('original_document', None)
     context = {
         'applications_data': applications_data,
         'applications_fields': applications_fields,
@@ -190,6 +190,7 @@ def document_detail(request, document):
         'partners_fields': partners_fields,
         'branches': branches,
         'branches_fields': branches_fields,
+        'original_document': original_document,
     }
     return render(request, 'specials/document-detail.html', context)
 

--- a/core/views_special.py
+++ b/core/views_special.py
@@ -137,7 +137,6 @@ def document_detail(request, document):
         partners_data = \
             Socios.objects.filter(cnpj__startswith=doc_prefix)\
                           .order_by('nome_socio')
-        partner = partners_data.first()
         company = Empresas.objects.filter(cnpj=obj.document).first()
         obj_dict['state'] = company.uf if company else ''
         companies_data = Holdings.objects.filter(cnpj_socia__startswith=doc_prefix)\

--- a/core/views_special.py
+++ b/core/views_special.py
@@ -79,7 +79,7 @@ def document_detail(request, document):
     branches_cnpjs = []
 
     if cnpj_search:  # CNPJ
-        branches = Documents.objects.filter(document__startswith=doc_prefix)
+        branches = Documents.objects.filter(docroot=doc_prefix)
         if not branches.exists():
             raise Http404()
         try:
@@ -90,7 +90,7 @@ def document_detail(request, document):
             else:
                 headquarter = doc_prefix + '0001'
                 try:
-                    obj = branches.get(document__startswith=headquarter)
+                    obj = branches.get(docroot=headquarter)
                 except Documents.DoesNotExist:
                     obj = branches[0]
             url = reverse('core:special-document-detail', args=[obj.document]) + "?original_document={}".format(document)

--- a/core/views_special.py
+++ b/core/views_special.py
@@ -129,19 +129,26 @@ def document_detail(request, document):
         remove=[],
     )
     if obj.document_type == 'CNPJ':
-        # TODO: use only its root (document[:8]) on all appearances of 'obj.document'
         partners_data = \
-            Socios.objects.filter(cnpj=obj.document)\
+            Socios.objects.filter(cnpj__startswith=doc_prefix)\
                           .order_by('nome_socio')
         partner = partners_data.first()
         company = Empresas.objects.filter(cnpj=obj.document).first()
         obj_dict['state'] = company.uf if company else ''
-        companies_data = Holdings.objects.filter(cnpj_socia=obj.document)\
+        companies_data = Holdings.objects.filter(cnpj_socia__startswith=doc_prefix)\
                                          .order_by('razao_social')
         companies_fields = _get_fields(
             datasets['socios-brasil']['holdings'],
             remove=['cnpj_socia'],
         )
+
+        # all appearances of 'obj.document'
+        camara_spending_data = \
+            GastosDeputados.objects.filter(txtcnpjcpf__startswith=doc_prefix)\
+                                   .order_by('-datemissao')
+        federal_spending_data = \
+            GastosDiretos.objects.filter(codigo_favorecido__startswith=doc_prefix)\
+                                 .order_by('-data_pagamento')
     elif obj.document_type == 'CPF':
         companies_data = \
             Socios.objects.filter(nome_socio=unaccent(obj.name))\
@@ -152,14 +159,13 @@ def document_detail(request, document):
         filiations_data = \
             FiliadosPartidos.objects.filter(nome_do_filiado=unaccent(obj.name))
 
-    # TODO: if len(document) == 14 (CNPJ) use only its root (document[:8]) on
-    # all appearances of 'obj.document'
-    camara_spending_data = \
-        GastosDeputados.objects.filter(txtcnpjcpf=obj.document)\
-                               .order_by('-datemissao')
-    federal_spending_data = \
-        GastosDiretos.objects.filter(codigo_favorecido=obj.document)\
-                             .order_by('-data_pagamento')
+        # all appearances of 'obj.document'
+        camara_spending_data = \
+            GastosDeputados.objects.filter(txtcnpjcpf=obj.document)\
+                                   .order_by('-datemissao')
+        federal_spending_data = \
+            GastosDiretos.objects.filter(codigo_favorecido=obj.document)\
+                                 .order_by('-data_pagamento')
 
     context = {
         'applications_data': applications_data,

--- a/core/views_special.py
+++ b/core/views_special.py
@@ -95,6 +95,7 @@ def document_detail(request, document):
                     obj = branches[0]
             url = reverse('core:special-document-detail', args=[obj.document]) + "?original_document={}".format(document)
             return redirect(url)
+        branches = branches.exclude(pk=obj.pk).order_by('document')
 
     else:
         obj = get_object_or_404(Documents, document=document)
@@ -128,6 +129,11 @@ def document_detail(request, document):
         datasets['filiados-partidos']['filiados'],
         remove=[],
     )
+    branches_fields = _get_fields(
+        datasets['documentos-brasil']['documents'],
+        remove=['document_type', 'sources', 'text'],
+    )
+
     if obj.document_type == 'CNPJ':
         partners_data = \
             Socios.objects.filter(cnpj__startswith=doc_prefix)\
@@ -182,6 +188,8 @@ def document_detail(request, document):
         'obj': obj_dict,
         'partners_data': partners_data,
         'partners_fields': partners_fields,
+        'branches': branches,
+        'branches_fields': branches_fields,
     }
     return render(request, 'specials/document-detail.html', context)
 


### PR DESCRIPTION
Fixes #77 

@turicas seria bom você dar uma testada porque não estou com todos os datasets carregados ainda. Na real só faltou eu validar os de gastos diretos e cota parlamentar. A listagem de sócio eu já validei com os exemplos da Globo Aviação.

Além disso, fiz o erro de carregar eles sem os índices, o que me atrasou muito a recuperar os resultados.

Enquanto o campo `docroot` não for adicionado no dataset, é necessário executar os seguintes comandos diretamente no postgres:

```sql
alter table data_documentosbrasil_documents add docroot  integer;
update data_documentosbrasil_documents set docroot = cast(substring(document from 1 for 8) as integer) where document_type='CNPJ';
create index on data_documentosbrasil_documents (docroot);
```

Segue o meu output com `\timing` ligado:

```
brasilio=# update data_documentosbrasil_documents set docroot = cast(substring(document from 1 for 8) as integer) where document_type='CNPJ';


UPDATE 9183548
Time: 845930,342 ms

brasilio=# create index docroot_idx on data_documentosbrasil_documents (docroot);
CREATE INDEX
Time: 201125,131 ms

brasilio=# select document from data_documentosbrasil_documents where docroot=15102288;
    document    
----------------
 15102288000182
 15102288031495
 15102288031819
(3 rows)

Time: 23,797 ms
```