### PR TITLE
Removes naomi app on debug mode

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -53,7 +53,6 @@ MIDDLEWARE = [
 ]
 if DEBUG:
     MIDDLEWARE.append('utils.sqlprint.SqlPrintingMiddleware')
-    INSTALLED_APPS += ('naomi',)
 
 ROOT_URLCONF = 'brasilio.urls'
 TEMPLATES = [


### PR DESCRIPTION
The commit b935e082b replaced naomi with mailhog and it seems the naomi
app was kept in INSTALLED_APPS declaration when DEBUG == True. Since in
the referred commit the naomi dependency was removed from requirements
file, the project is currently failing to run in debug mode in a fresh
install.

This change removes the naomi app from INSTALLED_APPS when DEBUG ==
True.

Signed-off-by: Caio Carrara <eu@caiocarrara.com.br>