### PR TITLE
Fix tests failing because simple password

### DIFF
--- a/brasilio_auth/tests/test_forms.py
+++ b/brasilio_auth/tests/test_forms.py
@@ -19,7 +19,7 @@ class UserCreationFormTests(TestCase):
         assert issubclass(UserCreationForm, DjangoUserCreationForm)
 
     def test_create_user(self):
-        passwd = 'qweasdzxc'
+        passwd = 'bras1li0?'
         data = {
             'username': 'foo',
             'email': 'foo@bar.com',

--- a/brasilio_auth/tests/test_views.py
+++ b/brasilio_auth/tests/test_views.py
@@ -10,7 +10,7 @@ class UserCreationViewTests(TestCase):
 
     def setUp(self):
         self.url = reverse('brasilio_auth:sign_up')
-        passwd = 'qweasdzxc'
+        passwd = 'bras1li0?'
         self.data = {
             'username': 'foo',
             'email': 'foo@bar.com',

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ networkx==2.1
 openpyxl
 psycopg2-binary
 py2neo==3.1.2
-pytest-django==3.2.1
+pytest-django==3.4.7
 requests
 requests-cache
 sendgrid-django


### PR DESCRIPTION
Upgrades pytest-django version and the password being used for tests.

The previous password being used was making tests fail because it was
too simple and it wasn't passing by django password validations.

Signed-off-by: Caio Carrara <eu@caiocarrara.com.br>