### PR TITLE
Add button in Newsletter Subscribers admin to export CSV

### DIFF
--- a/brasilio_auth/admin.py
+++ b/brasilio_auth/admin.py
@@ -1,10 +1,45 @@
+import csv
+
 from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
+from django.urls import path
+from django.http import StreamingHttpResponse
 
 from brasilio_auth.models import NewsletterSubscriber
+from brasilio_auth.services import subscribers_as_csv_rows
+
+
+class Echo:
+    def write(self, value):
+        return value
+
 
 
 class NewsletterSubscriberAdmin(admin.ModelAdmin):
     list_display = ['user']
+
+    def get_urls(self):
+        urls = super().get_urls()
+        my_urls = [
+            path('export/', self.export_subscribers_csv_view, name='subscribers-export'),
+        ]
+        return my_urls + urls
+
+    @staff_member_required
+    def export_subscribers_csv_view(self, request):
+        rows = subscribers_as_csv_rows()
+
+        ### we can refactor this later
+        ### copied from core/views.py
+        pseudo_buffer = Echo()
+        writer = csv.writer(pseudo_buffer, dialect=csv.excel)
+        response = StreamingHttpResponse(
+            (writer.writerow(row) for row in rows),
+            content_type="text/csv;charset=UTF-8",
+        )
+        response["Content-Disposition"] = 'attachment; filename="newsletter_subscribers.csv"'
+        response.encoding = "UTF-8"
+        return response
 
 
 admin.site.register(NewsletterSubscriber, NewsletterSubscriberAdmin)

--- a/brasilio_auth/admin.py
+++ b/brasilio_auth/admin.py
@@ -16,6 +16,7 @@ class Echo:
 
 
 class NewsletterSubscriberAdmin(admin.ModelAdmin):
+    change_list_template = 'brasilio_auth/newslettersubscribers_change_list.html'
     list_display = ['user']
 
     def get_urls(self):

--- a/brasilio_auth/services.py
+++ b/brasilio_auth/services.py
@@ -1,0 +1,13 @@
+from brasilio_auth.models import NewsletterSubscriber
+
+
+def subscribers_as_csv_rows(include_header=True):
+    rows = []
+    if include_header:
+        rows.append(('name','email'))
+
+    qs = NewsletterSubscriber.objects.select_related('user')
+    for user in [subscriber.user for subscriber in qs]:
+        rows.append((user.get_full_name(), user.email))
+
+    return rows

--- a/brasilio_auth/templates/brasilio_auth/newslettersubscribers_change_list.html
+++ b/brasilio_auth/templates/brasilio_auth/newslettersubscribers_change_list.html
@@ -1,0 +1,6 @@
+{% extends 'admin/change_list.html' %}
+
+{% block object-tools-items %}
+  <li><a href="{% url 'admin:subscribers-export' %}">Export Subscribers</a></li>
+  {{ block.super }}
+{% endblock %}

--- a/brasilio_auth/tests/test_forms.py
+++ b/brasilio_auth/tests/test_forms.py
@@ -19,7 +19,7 @@ class UserCreationFormTests(TestCase):
         assert issubclass(UserCreationForm, DjangoUserCreationForm)
 
     def test_create_user(self):
-        passwd = 'qweasdzxc'
+        passwd = 'someverygoodpassword'
         data = {
             'username': 'foo',
             'email': 'foo@bar.com',

--- a/brasilio_auth/tests/test_models.py
+++ b/brasilio_auth/tests/test_models.py
@@ -1,0 +1,36 @@
+from model_mommy import mommy
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from brasilio_auth.models import NewsletterSubscriber
+from brasilio_auth.services import subscribers_as_csv_rows
+
+
+User = get_user_model()
+
+class TestSubscribersAsCSVRows(TestCase):
+
+    def setUp(self):
+        users = mommy.make(
+            User,
+            _quantity=5,
+            _fill_optional=True
+        )
+        self.subscribers = [mommy.make(NewsletterSubscriber, user=u) for u in users]
+
+    def test_get_csv_rows(self):
+        rows = subscribers_as_csv_rows()
+
+        assert len(rows) == len(self.subscribers) + 1
+        assert ('name', 'email') == rows[0]
+
+        for user in [s.user for s in self.subscribers]:
+            assert (user.get_full_name(), user.email) in rows
+
+    def test_get_csv_rows_without_header(self):
+        rows = subscribers_as_csv_rows(include_header=False)
+
+        assert len(rows) == len(self.subscribers)
+        for user in [s.user for s in self.subscribers]:
+            assert (user.get_full_name(), user.email) in rows

--- a/brasilio_auth/tests/test_views.py
+++ b/brasilio_auth/tests/test_views.py
@@ -10,7 +10,7 @@ class UserCreationViewTests(TestCase):
 
     def setUp(self):
         self.url = reverse('brasilio_auth:sign_up')
-        passwd = 'qweasdzxc'
+        passwd = 'someverygoodpassword'
         self.data = {
             'username': 'foo',
             'email': 'foo@bar.com',


### PR DESCRIPTION
Add new URL: `/admin/brasilio_auth/newslettersubscriber/export/` that answers a CSV with all subscribers' name and email.

**Admin page**
![Screenshot from 2019-04-16 20-01-53](https://user-images.githubusercontent.com/238223/56249659-f7bec380-6082-11e9-9716-71cc866bef88.png)

**Sample CSV**
name,email
bernardo fontes,bernardoxhc@gmial.com
