### PR TITLE
Added language in README.md to include installing Python 3.6.4 using pyenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git clone git@github.com:turicas/brasil.io.git
 Siga os passos:
 
 ```bash
-# Instale o Python 3.6.4 usando o pyenv, caso j√°n√o o tenha feito:
+# Instale o Python 3.6.4 usando o pyenv:
 pyenv install 3.6.4
 
 # Criar um virtualenv:
@@ -109,6 +109,9 @@ fi
 e siga os passos:
 
 ```bash
+# Instale o Python 3.6.4 usando o pyenv:
+pyenv install 3.6.4
+
 # Criar um virtualenv:
 pyenv virtualenv 3.6.4 brasil.io
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ git clone git@github.com:turicas/brasil.io.git
 Siga os passos:
 
 ```bash
+# Instale o Python 3.6.4 usando o pyenv, caso j√°n√o o tenha feito:
+pyenv install 3.6.4
+
 # Criar um virtualenv:
 pyenv virtualenv 3.6.4 brasil.io
 


### PR DESCRIPTION
By adding language to install Python 3.6.4 using pyenv, the next instruction ("Criar um virtualenv) should complete without errors. Even if they have Python 3.6.4 installed system-wide (which could be the current suggestion in the README file), users will likely get an error like "Python 3.6.4 not found in pyenv" if they haven't done so before. 