### PR TITLE
Docker health check command to PostgreSQL service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
             - ./docker/postgresql/postgresql.conf:/etc/postgresql/postgresql.conf
             - ./docker/postgresql/data:/var/lib/postgresql/data
         command: -c "config_file=/etc/postgresql/postgresql.conf"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 30s
+            retries: 3
 
     graph_db:
         image: neo4j:3.3


### PR DESCRIPTION
This is a very humble contribution since that I've just forked the project and started to play around on my machine.

It's a common and very useful practice to use service health checks on Docker, this allows us to monitor and trigger some actions in case of service failure. Also, in a case of services dependency, one could use the service health information as a parameter for the other dependent service.