### PR TITLE
acrescenta no README passo faltante para instalação

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,15 @@ source .activate
 # Instalar dependências
 pip install -r requirements.txt
 
+# Iniciar os containers (bancos de dados, e-mail)
+docker-compuse up
+
 # Criar schema e popular base de dados
 python manage.py migrate
 python manage.py update_data
+
+# Iniciar o servidor HTTP
+python manage.py runserver
 ```
 
 Caso você escolha não utilizar o docker, siga os seguintes passos:


### PR DESCRIPTION
A documentação para instalação faltava o passo para subir os containers Docker.

```
docker-compose up
```

Agora, alguém seguindo o passo a passo, vai conseguir fazer rodar a aplicação.