### PR TITLE
Algumas correções para o #166

### DIFF
--- a/core/util.py
+++ b/core/util.py
@@ -7,6 +7,7 @@ import lzma
 from textwrap import dedent
 from functools import lru_cache
 from urllib.request import urlopen, URLError
+import socket
 
 import django.db.models.fields
 from django.db import connection, reset_queries, transaction
@@ -72,6 +73,8 @@ def github_repository_contributors(username, repository, timeout=1):
         response = urlopen(url, timeout=timeout)
     except URLError:
         return []
+    except socket.timeout:
+        return []
     else:
         contributors = json.loads(response.read())
         result = []
@@ -79,7 +82,7 @@ def github_repository_contributors(username, repository, timeout=1):
             url = contributor["url"]
             try:
                 response = urlopen(url, timeout=timeout)
-            except URLError:
+            except (URLError, socket.timeout):
                 continue
             result.append(json.loads(response.read()))
         return result

--- a/core/util.py
+++ b/core/util.py
@@ -67,22 +67,23 @@ def get_company_by_document(document):
 
 
 @lru_cache()
-def github_repository_contributors(username, repository, timeout=1):
-    url = f"https://api.github.com/repos/{username}/{repository}/contributors"
-    try:
-        response = urlopen(url, timeout=timeout)
-    except URLError:
-        return []
-    except socket.timeout:
-        return []
-    else:
-        contributors = json.loads(response.read())
-        result = []
-        for contributor in contributors:
-            url = contributor["url"]
-            try:
-                response = urlopen(url, timeout=timeout)
-            except (URLError, socket.timeout):
-                continue
-            result.append(json.loads(response.read()))
-        return result
+def github_repository_contributors(repositories = [], timeout=1):
+    result = []
+    for username, repository in repositories:
+        url = f"https://api.github.com/repos/{username}/{repository}/contributors"
+        try:
+            response = urlopen(url, timeout=timeout)
+        except URLError:
+            return result
+        except socket.timeout:
+            return result
+        else:
+            contributors = json.loads(response.read())
+            for contributor in contributors:
+                url = contributor["url"]
+                try:
+                    response = urlopen(url, timeout=timeout)
+                except (URLError, socket.timeout):
+                    continue
+                result.append(json.loads(response.read()))
+            return result

--- a/core/views.py
+++ b/core/views.py
@@ -200,8 +200,15 @@ def collaborate(request):
 
 
 def contributors(request):
+    repositories=(
+        ("turicas", "brasil.io"),
+        ("turicas", "blog.brasil.io"),
+        ("turicas", "socios-brasil"),
+        ("turicas", "eleicoes-brasil"),
+        ("turicas", "balneabilidade-brasil"),
+    )
     return render(
         request,
         "contributors.html",
-        {"contributors": github_repository_contributors("turicas", "brasil.io")},
+        {"contributors": github_repository_contributors(repositories)}
     )


### PR DESCRIPTION
* as exceções de *socket timeout* não dão mais uma página de erro, e sim uma tela vazia (melhorar isso no futuro para uma mensagem dizendo que o github não está respondendo)
* agora é possível especificar múltiplos repositórios de onde buscar os contribuidores