### PR TITLE
Substitui o model mommy pelo model bakery

### DIFF
--- a/brasilio_auth/tests/test_services.py
+++ b/brasilio_auth/tests/test_services.py
@@ -1,4 +1,4 @@
-from model_mommy import mommy
+from model_bakery import baker
 
 from django.test import TestCase
 from django.contrib.auth import get_user_model
@@ -12,12 +12,12 @@ User = get_user_model()
 class TestSubscribersAsCSVRows(TestCase):
 
     def setUp(self):
-        users = mommy.make(
+        users = baker.make(
             User,
             _quantity=5,
             _fill_optional=True
         )
-        self.subscribers = [mommy.make(NewsletterSubscriber, user=u) for u in users]
+        self.subscribers = [baker.make(NewsletterSubscriber, user=u) for u in users]
 
     def test_get_csv_rows(self):
         rows = subscribers_as_csv_rows()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+model-bakery==1.1.0


### PR DESCRIPTION
Esse PR é só mais para remover o uso do model_mommy de acordo com as [instruções na documentação](https://model-bakery.readthedocs.io/en/latest/migrating_from_mommy.html).