### PR TITLE
Usa o esquema salvo no banco durante o import data

### DIFF
--- a/core/management/commands/import_data.py
+++ b/core/management/commands/import_data.py
@@ -73,6 +73,7 @@ class Command(BaseCommand):
                     create_table=False,
                     timeout=timeout,
                     callback=progress.update,
+                    schema=table.get_schema(),
                 )
             except RuntimeError as exception:
                 progress.close()

--- a/core/management/commands/import_data.py
+++ b/core/management/commands/import_data.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
                     create_table=False,
                     timeout=timeout,
                     callback=progress.update,
-                    schema=table.get_schema(),
+                    schema=table.schema,
                 )
             except RuntimeError as exception:
                 progress.close()

--- a/core/models.py
+++ b/core/models.py
@@ -438,6 +438,9 @@ class Table(models.Model):
         Model = self.get_model()
         return model_to_code(Model)
 
+    def get_schema(self):
+        return dict(self.fields.values_list('name', 'type'))
+
 
 class FieldQuerySet(models.QuerySet):
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,49 @@
+from collections import OrderedDict
+from model_bakery import baker, seq
+from rows import fields
+
 from django.test import TestCase
 
-# Create your tests here.
+class TableModelTests(TestCase):
+
+    def test_schema_as_ordered_dict(self):
+        table = baker.make('core.Table')
+        fields = baker.make(
+            'core.Field', table=table,
+            name=seq('field_'),
+            dataset=table.dataset,
+            order=seq(1),
+            _quantity=10,
+        )
+
+        assert isinstance(table.schema, OrderedDict)
+        field_names = list(table.schema.keys())
+        for i, field in enumerate(fields):
+            assert field.name == field_names[i]
+
+    def test_schema_fields_types(self):
+        db_fields_to_rows_fields = {
+            'binary': fields.BinaryField,
+            'bool': fields.BoolField,
+            'date': fields.DateField,
+            'datetime': fields.DatetimeField,
+            'decimal': fields.DecimalField,
+            'email': fields.EmailField,
+            'float': fields.FloatField,
+            'integer': fields.IntegerField,
+            'json': fields.JSONField,
+            'string': fields.TextField,
+            'text': fields.TextField,
+        }
+
+        table = baker.make('core.Table')
+        field = baker.prepare(
+            'core.Field', table=table, name='table_column', dataset=table.dataset
+        )
+
+        for db_field_type, rows_field_type in db_fields_to_rows_fields.items():
+            field.type = db_field_type
+            field.save()
+            table.refresh_from_db()
+
+            assert rows_field_type == table.schema['table_column']


### PR DESCRIPTION
Esse PR adiciona um novo método ao model de table para recuperar o schema da tabela. Segue um exemplo seu uso:

```python
In [2]: table.get_schema()                                                                                                                                                   
Out[2]: {'campo_2': 'json', 'campo_1': 'float'}
```

Fix este método retornar um dictionário para respeitar o que [a funçao `pgimport` da rows espera](https://github.com/turicas/rows/blob/develop/rows/utils.py#L918).

Fixes #184 