### PR TITLE
Cacheia o site inteiro para usuários não logados

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -47,9 +47,11 @@ MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
+    'django.middleware.cache.UpdateCacheMiddleware',
+    'django.middleware.common.CommonMiddleware',
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    'core.middlewares.NotLoggedUserFetchFromCacheMiddleware',
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -171,6 +173,9 @@ RECAPTCHA_PRIVATE_KEY = env("RECAPTCHA_PRIVATE_KEY")
 ROWS_PER_PAGE = env("ROWS_PER_PAGE", int, default=50)
 
 CACHALOT_ENABLED = env("CACHE_ENABLED", bool, default=True)
+CACHE_MIDDLEWARE_ALIAS = 'default'
+CACHE_MIDDLEWARE_SECONDS = 600  # 10 minutes
+CACHE_MIDDLEWARE_KEY_PREFIX = 'non_logged_user_'
 CACHALOT_CACHE = "default"
 CACHES = {
     "default": {

--- a/core/middlewares.py
+++ b/core/middlewares.py
@@ -1,0 +1,12 @@
+from django.middleware.cache import FetchFromCacheMiddleware
+
+
+class NotLoggedUserFetchFromCacheMiddleware(FetchFromCacheMiddleware):
+
+    def process_request(self, request):
+        """
+        If no auth user, check whether the page is already cached and return
+        the cached version if available.
+        """
+        if not request.user.is_authenticated:
+            return super().process_request(request)


### PR DESCRIPTION
Nesse PR eu introduzo uma especificação do middleware do Django para fazer [per-site cache](https://docs.djangoproject.com/en/3.0/topics/cache/#the-per-site-cache). A única coisa que precisei fazer de diferente do que diz a documentação, além de checar se o usuário está logado ou não, foi colocar esse middleware depois do middleware de autenticação do Django. 

Escolhi deixar o cache **vivo por 10 minutos** para não sobrecarregar a memória do servidor por hora. Mas aconselho configurar o [limite máximo de memória do redis](https://stackoverflow.com/questions/33115325/how-to-set-redis-max-memory#33119590) no servidor. Infelizmente não tenho como fazer isso no Django. 

De acordo com a documentação do Django, a estratégia de cache é a seguinte:

>  **FetchFromCacheMiddleware** caches GET and HEAD responses with status 200, where the request and response headers allow. Responses to requests for the same URL with different query parameters are considered to be unique pages and are cached separately. This middleware expects that a HEAD request is answered with the same response headers as the corresponding GET request; in which case it can return a cached GET response for HEAD request.

> Additionally, **UpdateCacheMiddleware** automatically sets a few headers in each **HttpResponse**:

> - Sets the **Expires** header to the current date/time plus the defined `CACHE_MIDDLEWARE_SECONDS`.
> - Sets the **Cache-Control** header to give a max age for the page – again, from the `CACHE_MIDDLEWARE_SECONDS` setting.
