### PR TITLE
Limita tempo máximo de consultas no banco para 20s somente para requisições web

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -81,6 +81,7 @@ WSGI_APPLICATION = "brasilio.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 DATABASES = {"default": env.db("DATABASE_URL")}
+DB_STATEMENT_TIMEOUT = env("DB_STATEMENT_TIMEOUT", default=20000, cast=int)  # miliseconds
 
 
 # Password validation

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -1,5 +1,3 @@
-import os
-
 import environ
 
 from urllib.parse import urlparse

--- a/brasilio/wsgi.py
+++ b/brasilio/wsgi.py
@@ -22,7 +22,6 @@ def setup_postgres(connection, **kwargs):
     if connection.vendor != 'postgresql':
         return
 
-    # Timeout statements after 30 seconds.
     timeout = settings.DB_STATEMENT_TIMEOUT
     with connection.cursor() as cursor:
         cursor.execute(f"SET statement_timeout TO {timeout};")

--- a/brasilio/wsgi.py
+++ b/brasilio/wsgi.py
@@ -13,4 +13,18 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "brasilio.settings")
 
+from django.db.backends.signals import connection_created
+from django.dispatch import receiver
+from django.conf import settings
+
+@receiver(connection_created)
+def setup_postgres(connection, **kwargs):
+    if connection.vendor != 'postgresql':
+        return
+
+    # Timeout statements after 30 seconds.
+    timeout = settings.DB_STATEMENT_TIMEOUT
+    with connection.cursor() as cursor:
+        cursor.execute(f"SET statement_timeout TO {timeout};")
+
 application = get_wsgi_application()


### PR DESCRIPTION
Fixes #206 

Referência: https://hakibenita.com/9-django-tips-for-working-with-databases#statement-timeout

@turicas segue o log do meu terminal servindo a aplicação via `gunicorn` mostrantdo que o `SET TIMEOUT` foi chamado corretamente:

```
$ gunicorn brasilio.wsgi:application --bind=0.0.0.0:5000
[2020-04-14 14:57:08 -0300] [3104] [INFO] Starting gunicorn 19.9.0
[2020-04-14 14:57:08 -0300] [3104] [INFO] Listening at: http://0.0.0.0:5000 (3104)
[2020-04-14 14:57:08 -0300] [3104] [INFO] Using worker: sync
[2020-04-14 14:57:08 -0300] [3107] [INFO] Booting worker with pid: 3107
  [0.000] SET statement_timeout TO 20000;

  [0.002] SELECT t.oid,  typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore'

  [0.000] SELECT typarray FROM pg_type WHERE typname = 'citext'

  [0.001] SELECT django_session.session_key,  django_session.session_data,  django_session.expire_date FROM django_session WHERE (django_session.expire_date > '20
  20-04-14T17:57:15.761300+00:00'::timestamptz AND django_session.session_key = '13t455nqth492vtw6mtdgx3ci05wfe52')

  [0.001] SELECT auth_user.id,  auth_user.password,  auth_user.last_login,  auth_user.is_superuser,  auth_user.username,  auth_user.first_name,  auth_user.last_na
  me,  auth_user.email,  auth_user.is_staff,  auth_user.is_active,  auth_user.date_joined FROM auth_user WHERE auth_user.id = 1

  [TOTAL TIME: 0.004 seconds]
```