### PR TITLE
Corrige o posicionamento de alguns elementos durante a navegação mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ data/*
 dist/*
 docker/neo4j
 docker/redis
-docker/postgres/data
+docker/postgresql/data
 public/
 reg_settings.py
 .vscode/

--- a/static/css/application.css
+++ b/static/css/application.css
@@ -12,7 +12,6 @@ html {
 body {
   position: relative;
   margin: 0;
-  padding-bottom: 12rem;
   min-height: 100%;
   font-family: Roboto, sans-serif;
   font-weight: 300;
@@ -74,7 +73,7 @@ body {
 }
 
 .card .card-content.card-body {
-  height: 100px;
+  min-height: 100px;
 }
 
 .card.small .card-description {
@@ -83,10 +82,6 @@ body {
 
 .footer {
   text-align: center;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
 }
 
 .email-newsletter {


### PR DESCRIPTION
Fixes #221 

- Corrige a sobreposição do último elemento do `body` sob o `footer` da página;
- Corrige a altura dos `cards` que cortavam a exibição na íntegra do conteúdo;
- Atualiza o nome da pasta `docker/postgresql` no `.gitignore`.

**Footer Mobile**
antes | depois
----- | ------- 
<img width="359" alt="Screen Shot 2020-05-03 at 19 29 11" src="https://user-images.githubusercontent.com/660003/80928676-6cdb6480-8d7c-11ea-9bdb-c4e219a414d5.png"> | <img width="360" alt="Screen Shot 2020-05-03 at 19 33 48" src="https://user-images.githubusercontent.com/660003/80928677-71078200-8d7c-11ea-9fb8-8caa937b899e.png">

**Card Mobile**
antes | depois
----- | ------- 
<img width="358" alt="Screen Shot 2020-05-03 at 19 44 51" src="https://user-images.githubusercontent.com/660003/80928765-0145c700-8d7d-11ea-86fd-bea390e65f63.png"> | <img width="360" alt="Screen Shot 2020-05-03 at 19 45 26" src="https://user-images.githubusercontent.com/660003/80928767-0571e480-8d7d-11ea-869a-cbda652455f6.png">