### PR TITLE
Permite download dos modelos de importação para os estados

### DIFF
--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -1,5 +1,8 @@
+from django.urls import path
+
 from django.contrib import admin
 from django.db import transaction
+from django.http import HttpResponse
 from django.templatetags.static import static
 from django.utils.html import format_html
 
@@ -46,6 +49,17 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
     form = StateSpreadsheetForm
     ordering = ["-created_at"]
     add_form_template = "admin/covid19_add_form.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "planilha-model/<str:state>/",
+                self.admin_site.admin_view(self.sample_spreadsheet_view),
+                name="sample_covid_spreadsheet",
+            ),
+        ]
+        return custom_urls + urls
 
     def get_readonly_fields(self, request, obj=None):
         fields = []
@@ -111,6 +125,9 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
         extra_context["allowed_states"] = allowed_states
         kwargs["extra_context"] = extra_context
         return super().add_view(request, *args, **kwargs)
+
+    def sample_spreadsheet_view(self, request, state):
+        return HttpResponse(state)
 
 
 admin.site.register(StateSpreadsheet, StateSpreadsheetModelAdmin)

--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -43,6 +43,7 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
     list_filter = [StateFilter, "status", ActiveFilter]
     form = StateSpreadsheetForm
     ordering = ["-created_at"]
+    add_form_template = "admin/covid19_add_form.html"
 
     def get_readonly_fields(self, request, obj=None):
         fields = []

--- a/covid19/forms.py
+++ b/covid19/forms.py
@@ -53,6 +53,11 @@ class StateSpreadsheetForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if self.user:
             self.fields["state"].choices = state_choices_for_user(self.user)
+
+        help = (
+            'Caso necessário, baixe o arquivo modelo para os estados clicando nos botões acima entitulados "Modelo XX".'
+        )
+        self.fields["state"].help_text = help
         self.file_data_as_json = []
         self.data_warnings = []
 

--- a/covid19/forms.py
+++ b/covid19/forms.py
@@ -57,7 +57,8 @@ class StateSpreadsheetForm(forms.ModelForm):
         help = (
             'Caso necessário, baixe o arquivo modelo para os estados clicando nos botões acima entitulados "Modelo XX".'
         )
-        self.fields["state"].help_text = help
+        if "state" in self.fields:
+            self.fields["state"].help_text = help
         self.file_data_as_json = []
         self.data_warnings = []
 

--- a/covid19/templates/admin/covid19_add_form.html
+++ b/covid19/templates/admin/covid19_add_form.html
@@ -1,0 +1,1 @@
+{% extends "admin/change_form.html" %}

--- a/covid19/templates/admin/covid19_add_form.html
+++ b/covid19/templates/admin/covid19_add_form.html
@@ -1,1 +1,10 @@
 {% extends "admin/change_form.html" %}
+
+
+{% block object-tools %}
+  <ul class="object-tools">
+    {% for state in allowed_states %}
+    <li><a href="{% url 'admin:sample_covid_spreadsheet' state.acronym %}">Modelo {{ state.acronym }}</a></li>
+    {% endfor %}
+  </ul>
+{% endblock %}


### PR DESCRIPTION
Fixes #216 

Esse PR adiciona uma view somente acessível para usuárias colaboradoras do dataset do Covid19 para fazer o download do CSV template dos estados de acordo com suas permissões. 

Na interface, isso é possível através dos botões de ação que ficam no topo da página, a esquerda do título. Além disso, adicionei um texto de ajuda no campo de seleção de estados. Segue o print final da página:

![Screenshot from 2020-05-04 14-14-14](https://user-images.githubusercontent.com/238223/80993762-03a63080-8e12-11ea-8815-9340ef4aa2d0.png)
