### PR TITLE
Melhora notificações no RocketChat

### DIFF
--- a/covid19/notifications.py
+++ b/covid19/notifications.py
@@ -62,5 +62,10 @@ def notify_import_success(spreadsheet):
 
     msg = f"@turicas planilha de *{spreadsheet.state}* para o dia *{spreadsheet.date}* checada (dados enviados por {authors}), pode rodar o deploy!"  # noqa
     msg += f"\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
+    chat.send_message(channel, msg)
 
+    channel, collabs = notification_info_by_state(spreadsheet.state)
+
+    msg = f"{collabs} - planilha de *{spreadsheet.state}* para o dia *{spreadsheet.date}* checada pronta para o deploy!"  # noqa
+    msg += f"\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
     chat.send_message(channel, msg)

--- a/covid19/notifications.py
+++ b/covid19/notifications.py
@@ -38,7 +38,7 @@ def notify_new_spreadsheet(spreadsheet):
     channel, collabs = notification_info_by_state(spreadsheet.state)
 
     msg = f"{collabs} - *Nova planilha* importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"
-    msg += f"\nRealizada por: *{spreadsheet.user.username}*\n\nPrecisamos de mais uma planilha para verificar os dados."
+    msg += f"\nRealizada por: *@{spreadsheet.user.username}*\n\nPrecisamos de mais uma planilha para verificar os dados."  # noqa
     msg += "\nOs dados só poderão ser atualizados se uma nova planilha for enviada e os dados forem os mesmos."
 
     chat.send_message(channel, msg)
@@ -50,7 +50,7 @@ def notify_spreadsheet_mismatch(spreadsheet, errors):
 
     errors = "\n- ".join(errors)
     msg = f"{collabs} - *Dados divergentes* na planilha importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"  # noqa
-    msg += f"\nRealizada por: *{spreadsheet.user.username}*\n\n- {errors}"
+    msg += f"\nRealizada por: *@{spreadsheet.user.username}*\n\n- {errors}"
     msg += f"\n\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
 
     chat.send_message(channel, msg)
@@ -59,7 +59,7 @@ def notify_spreadsheet_mismatch(spreadsheet, errors):
 def notify_import_success(spreadsheet):
     chat = get_chat()
     channel = "#covid19"
-    authors = " e ".join([spreadsheet.user.username, spreadsheet.peer_review.user.username,])
+    authors = " e ".join([f"@{spreadsheet.user.username}", f"@{spreadsheet.peer_review.user.username}",])
 
     msg = f"@turicas planilha de *{spreadsheet.state}* para o dia *{spreadsheet.date}* checada (dados enviados por {authors}), pode rodar o deploy!"  # noqa
     msg += f"\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
@@ -68,5 +68,6 @@ def notify_import_success(spreadsheet):
     channel, collabs = notification_info_by_state(spreadsheet.state)
 
     msg = f"{collabs} - planilha de *{spreadsheet.state}* para o dia *{spreadsheet.date}* checada pronta para o deploy!"  # noqa
+    msg += f"\nDados enviados por {authors}"
     msg += f"\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
     chat.send_message(channel, msg)

--- a/covid19/notifications.py
+++ b/covid19/notifications.py
@@ -25,12 +25,17 @@ def clean_collaborators(collaborators):
     return ["@" + c.strip() for c in collaborators.split(",")]
 
 
-def notify_new_spreadsheet(spreadsheet):
-    chat = get_chat()
-    state_info = import_info_by_state(spreadsheet.state)
+def notification_info_by_state(state):
+    state_info = import_info_by_state(state)
     channel = state_info.canal
     collabs = clean_collaborators(state_info.voluntarios)
     collabs = " ".join(collabs)
+    return channel, collabs
+
+
+def notify_new_spreadsheet(spreadsheet):
+    chat = get_chat()
+    channel, collabs = notification_info_by_state(spreadsheet.state)
 
     msg = f"{collabs} - *Nova planilha* importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"
     msg += f"\nRealizada por: *{spreadsheet.user.username}*\n\nPrecisamos de mais uma planilha para verificar os dados."
@@ -41,10 +46,7 @@ def notify_new_spreadsheet(spreadsheet):
 
 def notify_spreadsheet_mismatch(spreadsheet, errors):
     chat = get_chat()
-    state_info = import_info_by_state(spreadsheet.state)
-    channel = state_info.canal
-    collabs = clean_collaborators(state_info.voluntarios)
-    collabs = " ".join(collabs)
+    channel, collabs = notification_info_by_state(spreadsheet.state)
 
     errors = "\n- ".join(errors)
     msg = f"{collabs} - *Dados divergentes* na planilha importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"  # noqa

--- a/covid19/notifications.py
+++ b/covid19/notifications.py
@@ -51,6 +51,7 @@ def notify_spreadsheet_mismatch(spreadsheet, errors):
     errors = "\n- ".join(errors)
     msg = f"{collabs} - *Dados divergentes* na planilha importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"  # noqa
     msg += f"\nRealizada por: *{spreadsheet.user.username}*\n\n- {errors}"
+    msg += f"\n\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
 
     chat.send_message(channel, msg)
 


### PR DESCRIPTION
Fixes #259
Fixes #261 

### Nova planilha importada
```
In [3]: notify_new_spreadsheet(sp)                                                                                                                                           
New message in #covid19-sul:
@guilherme.mendes @pedro.henrique @fernanda.scovino - *Nova planilha* importada para o estado *PR* para o dia *2020-04-23*
Realizada por: *@admin*

Precisamos de mais uma planilha para verificar os dados.
Os dados só poderão ser atualizados se uma nova planilha for enviada e os dados forem os mesmos.
```

### Erros de match

```
In [4]: notify_spreadsheet_mismatch(sp, ['error 1', 'error 2'])                                                                                                              
New message in #covid19-sul:
@guilherme.mendes @pedro.henrique @fernanda.scovino - *Dados divergentes* na planilha importada para o estado *PR* para o dia *2020-04-23*
Realizada por: *@admin*

- error 1
- error 2

Link para a planilha: https://brasil.io/admin/covid19/statespreadsheet/13/change/
```

### Pronta para ser deployada

Repare que o processo dispara 2 notificações em canais diferentes: 1 no #covid19 e outra no canal do estado.

```
In [5]: notify_import_success(sp)                                                                                                                                            
New message in #covid19:
@turicas planilha de *PR* para o dia *2020-04-23* checada (dados enviados por @admin e @bernardo), pode rodar o deploy!
Link para a planilha: https://brasil.io/admin/covid19/statespreadsheet/13/change/
New message in #covid19-sul:
@guilherme.mendes @pedro.henrique @fernanda.scovino - planilha de *PR* para o dia *2020-04-23* checada pronta para o deploy!
Dados enviados por @admin e @bernardo
Link para a planilha: https://brasil.io/admin/covid19/statespreadsheet/13/change/
```