### PR TITLE
Bugfixes na validação das planilhas

### DIFF
--- a/covid19/exceptions.py
+++ b/covid19/exceptions.py
@@ -5,10 +5,14 @@ class SpreadsheetValidationErrors(Exception):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.error_messages = []
+        self._error_messages = set()
 
     def new_error(self, msg):
-        self.error_messages.append(msg)
+        self._error_messages.add(msg)
+
+    @property
+    def error_messages(self):
+        return list(self._error_messages)
 
     def raise_if_errors(self):
         if self.error_messages:

--- a/covid19/notifications.py
+++ b/covid19/notifications.py
@@ -38,7 +38,7 @@ def notify_new_spreadsheet(spreadsheet):
     channel, collabs = notification_info_by_state(spreadsheet.state)
 
     msg = f"{collabs} - *Nova planilha* importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"
-    msg += f"\nRealizada por: *@{spreadsheet.user.username}*\n\nPrecisamos de mais uma planilha para verificar os dados."  # noqa
+    msg += f"\nRealizada por: @{spreadsheet.user.username}\n\nPrecisamos de mais uma planilha para verificar os dados."  # noqa
     msg += "\nOs dados só poderão ser atualizados se uma nova planilha for enviada e os dados forem os mesmos."
 
     chat.send_message(channel, msg)
@@ -50,7 +50,7 @@ def notify_spreadsheet_mismatch(spreadsheet, errors):
 
     errors = "\n- ".join(errors)
     msg = f"{collabs} - *Dados divergentes* na planilha importada para o estado *{spreadsheet.state}* para o dia *{spreadsheet.date}*"  # noqa
-    msg += f"\nRealizada por: *@{spreadsheet.user.username}*\n\n- {errors}"
+    msg += f"\nRealizada por: @{spreadsheet.user.username}\n\n- {errors}"
     msg += f"\n\nLink para a planilha: https://brasil.io{spreadsheet.admin_url}"
 
     chat.send_message(channel, msg)

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -55,6 +55,9 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state):
         confirmed = getattr(entry, confirmed_attr, None)
         deaths = getattr(entry, deaths_attr, None)
         if not city:
+            if confirmed or deaths:
+                msg = "Uma ou mais linhas com a coluna de cidade vazia possuem números de confirmados ou óbitos"
+                validation_errors.new_error(msg)
             continue
 
         if city in processed_cities:

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -63,6 +63,8 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state):
         processed_cities.add(city)
         if city == UNDEFINED_DISPLAY:
             has_undefined = True
+        elif city == TOTAL_LINE_DISPLAY:
+            has_total = True
 
         if (confirmed is None and deaths is not None) or (deaths is None and confirmed is not None):
             validation_errors.new_error(f"Dados de casos ou óbitos incompletos na linha {city}")
@@ -84,7 +86,6 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state):
             continue
 
         if result["place_type"] == "state":
-            has_total = True
             total_cases, total_deaths = confirmed, deaths
         else:
             sum_cases += confirmed

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -69,10 +69,14 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state):
         if confirmed is None or deaths is None:
             continue
 
-        if deaths > confirmed:
-            validation_errors.new_error(f"Valor de óbitos maior que casos confirmados na linha {city} da planilha")
-        elif deaths < 0 or confirmed < 0:
-            validation_errors.new_error(f"Valores negativos na linha {city} da planilha")
+        try:
+            if deaths > confirmed:
+                validation_errors.new_error(f"Valor de óbitos maior que casos confirmados na linha {city} da planilha")
+            elif deaths < 0 or confirmed < 0:
+                validation_errors.new_error(f"Valores negativos na linha {city} da planilha")
+        except TypeError:
+            validation_errors.new_error(f"Provavelmente há uma fórmula na linha {city} da planilha")
+            continue
 
         result = _parse_city_data(city, confirmed, deaths, date, state)
         if result["city_ibge_code"] == INVALID_CITY_CODE:

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -54,6 +54,8 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state):
         city = getattr(entry, city_attr, None)
         confirmed = getattr(entry, confirmed_attr, None)
         deaths = getattr(entry, deaths_attr, None)
+        if not city:
+            continue
 
         if city in processed_cities:
             validation_errors.new_error(f"Mais de uma entrada para {city}")

--- a/covid19/tests/data/sample-PR-empty-lines.csv
+++ b/covid19/tests/data/sample-PR-empty-lines.csv
@@ -1,0 +1,14 @@
+municipio,confirmados,mortes
+TOTAL NO ESTADO,102,32
+Importados/Indefinidos,2,2
+Abatiá,9,1
+Adrianópolis,11,2
+Agudos do Sul,12,3
+Almirante Tamandaré,8,4
+Altamira do Paraná,13,5
+Alto Paraíso,47,15
+,,
+,,
+,,
+,,
+,,

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -339,6 +339,16 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         exception = execinfo.value
         assert "Mais de uma entrada para Abatiá" in exception.error_messages
 
+    def test_validation_error_if_city_formyla(self):
+        self.content = self.content.replace("Abatiá,9,1", "Abatiá,'=SUM(A1:A3)',1")
+
+        file_rows = rows.import_from_csv(self.file_from_content)
+        with pytest.raises(SpreadsheetValidationErrors) as execinfo:
+            format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf)
+
+        exception = execinfo.value
+        assert "Provavelmente há uma fórmula na linha Abatiá da planilha" in exception.error_messages
+
 
 class TestValidateSpreadsheetWithHistoricalData(Covid19DatasetTestCase):
     def setUp(self):

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -315,6 +315,8 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         exception = execinfo.value
         msg = "Uma ou mais linhas com a coluna de cidade vazia possuem números de confirmados ou óbitos"
         assert msg in exception.error_messages
+        assert exception.error_messages.count(msg) == 1
+
     @patch("covid19.spreadsheet_validator.validate_historical_data")
     def test_validate_historical_data_as_the_final_validation(self, mock_validate_historical_data):
         mock_validate_historical_data.return_value = ["warning 1", "warning 2"]

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -306,7 +306,7 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         sample = settings.SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR-empty-lines.csv"
         assert sample.exists()
         self.content = sample.read_text()
-        self.content = self.content.replace(',,', ',10,20')
+        self.content = self.content.replace(",,", ",10,20")
 
         file_rows = rows.import_from_csv(self.file_from_content)
         with pytest.raises(SpreadsheetValidationErrors) as execinfo:

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -339,7 +339,7 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         exception = execinfo.value
         assert "Mais de uma entrada para Abatiá" in exception.error_messages
 
-    def test_validation_error_if_city_formyla(self):
+    def test_validation_error_if_city_formula(self):
         self.content = self.content.replace("Abatiá,9,1", "Abatiá,'=SUM(A1:A3)',1")
 
         file_rows = rows.import_from_csv(self.file_from_content)

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -302,6 +302,19 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         assert len(file_rows) > 8
         assert 8 == len(data)
 
+    def test_raise_error_if_empty_line_but_with_data(self):
+        sample = settings.SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR-empty-lines.csv"
+        assert sample.exists()
+        self.content = sample.read_text()
+        self.content = self.content.replace(',,', ',10,20')
+
+        file_rows = rows.import_from_csv(self.file_from_content)
+        with pytest.raises(SpreadsheetValidationErrors) as execinfo:
+            format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf)
+
+        exception = execinfo.value
+        msg = "Uma ou mais linhas com a coluna de cidade vazia possuem números de confirmados ou óbitos"
+        assert msg in exception.error_messages
     @patch("covid19.spreadsheet_validator.validate_historical_data")
     def test_validate_historical_data_as_the_final_validation(self, mock_validate_historical_data):
         mock_validate_historical_data.return_value = ["warning 1", "warning 2"]

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -290,6 +290,18 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
 
         assert data[0]["deaths"] == 50
 
+    @patch("covid19.spreadsheet_validator.validate_historical_data", Mock(return_value=[]))
+    def test_ignore_empty_lines_when_importing(self):
+        sample = settings.SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR-empty-lines.csv"
+        assert sample.exists()
+        self.content = sample.read_text()
+
+        file_rows = rows.import_from_csv(self.file_from_content)
+        data, warnings = format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf)
+
+        assert len(file_rows) > 8
+        assert 8 == len(data)
+
     @patch("covid19.spreadsheet_validator.validate_historical_data")
     def test_validate_historical_data_as_the_final_validation(self, mock_validate_historical_data):
         mock_validate_historical_data.return_value = ["warning 1", "warning 2"]

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -37,4 +37,4 @@ class ImportSpreadsheetProxyViewTests(TestCase):
         response = self.client.get(self.url)
 
         assert 400 == response.status_code
-        assert {"errors": ["error 1", "error 2"]} == response.json()
+        assert ["error 1", "error 2"] == sorted(response.json()['errors'])

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -37,4 +37,4 @@ class ImportSpreadsheetProxyViewTests(TestCase):
         response = self.client.get(self.url)
 
         assert 400 == response.status_code
-        assert ["error 1", "error 2"] == sorted(response.json()['errors'])
+        assert ["error 1", "error 2"] == sorted(response.json()["errors"])


### PR DESCRIPTION
Esse PR corrige 2 bugs:

- Ignora linhas em branco (valor nulo ou vazio para a coluna `municipio`);
- Levanta erro no caso de fórmulas para as colunas de `deaths` e `confirmed`;