### PR TITLE
Minimiza chances de erro em integração com Google Spreadsheet

### DIFF
--- a/covid19/google_data.py
+++ b/covid19/google_data.py
@@ -2,6 +2,7 @@ import io
 import rows
 from cache_memoize import cache_memoize
 from collections import namedtuple
+from retry import retry
 from urllib.parse import parse_qs, urlparse
 
 from core.util import http_get
@@ -41,6 +42,7 @@ def import_info_by_state(state):
     return StateData(**data)
 
 
+@retry(tries=3, delay=5)
 def get_state_data_from_google_spreadsheets(state, timeout=5):
     state_spreadsheet_url = import_info_by_state(state).planilha_brasilio
     state_spreadsheet_download_url = spreadsheet_download_url(state_spreadsheet_url, "xlsx")

--- a/covid19/google_data.py
+++ b/covid19/google_data.py
@@ -38,7 +38,7 @@ def get_general_spreadsheet(timeout=5):
 def import_info_by_state(state):
     states_data = get_general_spreadsheet()
     data = states_data[state.upper()]
-    StateData = namedtuple('StateData', data.keys())
+    StateData = namedtuple("StateData", data.keys())
     return StateData(**data)
 
 

--- a/covid19/google_data.py
+++ b/covid19/google_data.py
@@ -1,6 +1,6 @@
 import io
 import rows
-from cachetools import cached, TTLCache
+from cache_memoize import cache_memoize
 from urllib.parse import parse_qs, urlparse
 
 from core.util import http_get
@@ -26,11 +26,11 @@ def spreadsheet_download_url(url_or_id, file_format):
     )
 
 
-@cached(cache=TTLCache(maxsize=100, ttl=24 * 3600))
+@cache_memoize(24 * 3600)
 def get_general_spreadsheet(timeout=5):
     data = http_get(spreadsheet_download_url(STATE_LINKS_SPREADSHEET_ID, "csv"), timeout)
     table = rows.import_from_csv(io.BytesIO(data), encoding="utf-8")
-    return {row.uf: row for row in table}
+    return {row.uf: row._asdict() for row in table}
 
 
 def import_info_by_state(state):

--- a/covid19/google_data.py
+++ b/covid19/google_data.py
@@ -1,6 +1,7 @@
 import io
 import rows
 from cache_memoize import cache_memoize
+from collections import namedtuple
 from urllib.parse import parse_qs, urlparse
 
 from core.util import http_get
@@ -35,7 +36,9 @@ def get_general_spreadsheet(timeout=5):
 
 def import_info_by_state(state):
     states_data = get_general_spreadsheet()
-    return states_data[state.upper()]
+    data = states_data[state.upper()]
+    StateData = namedtuple('StateData', data.keys())
+    return StateData(**data)
 
 
 def get_state_data_from_google_spreadsheets(state, timeout=5):

--- a/covid19/tests/test_google_data.py
+++ b/covid19/tests/test_google_data.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.core.cache import cache
+
+from covid19 import google_data
+
+
+class TestGoogleDataIntegration(TestCase):
+    def test_cache_general_spreadsheet(self):
+        cache.clear()
+        assert not cache.keys("*")
+
+        data = google_data.get_general_spreadsheet(timeout=10)
+        cache_key = cache.keys("*")[0]
+
+        assert data
+        assert data == cache.get(cache_key)
+
+    def test_import_info_by_state_exposes_attr_api(self):
+        rj_data = google_data.import_info_by_state("RJ")
+
+        assert rj_data.uf == "RJ"
+
+    @patch("covid19.google_data.import_info_by_state")
+    def test_retry_to_fetch_google_spreadsheets_if_any_error(self, mock_import):
+        mock_import.side_effect = Exception()
+
+        with pytest.raises(Exception):
+            google_data.get_state_data_from_google_spreadsheets("RJ")
+
+        mock_import.assert_called_with("RJ")
+        assert 3 == mock_import.call_count

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ six>=1.13
 tqdm
 xlrd
 xlwt
+retry==0.9.2


### PR DESCRIPTION
Fixes #271 

@turicas pra deixar claro, esse PR não garante 100% que não teremos erros dado que, né, é integração com serviço externo, então a rede sempre pode atrapalhar. Mas, tanto a mudança de estratégia de cache quanto o retry devem diminuir a incidência de exceções levantadas por essas intgrações.