### PR TITLE
Adiciona opção de pular validações de soma

### DIFF
--- a/covid19/forms.py
+++ b/covid19/forms.py
@@ -52,6 +52,8 @@ class StateSpreadsheetForm(forms.ModelForm):
         required=False,
         help_text='Observações no boletim como "depois de publicar o boletim a secretaria postou no Twitter que teve mais uma morte".',  # noqa
     )
+    skip_sum_cases = forms.BooleanField(required=False, label="Ignorar validação de soma de casos",)
+    skip_sum_deaths = forms.BooleanField(required=False, label="Ignorar validação de soma de mortes",)
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
@@ -123,7 +125,11 @@ class StateSpreadsheetForm(forms.ModelForm):
 
             try:
                 self.file_data_as_json, self.data_warnings = format_spreadsheet_rows_as_dict(
-                    file_rows, spreadsheet_date, state
+                    file_rows,
+                    spreadsheet_date,
+                    state,
+                    skip_sum_cases=cleaned_data.get("skip_sum_cases", False),
+                    skip_sum_deaths=cleaned_data.get("skip_sum_deaths", False),
                 )
             except SpreadsheetValidationErrors as exception:
                 for error in exception.error_messages:

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -12,7 +12,7 @@ UNDEFINED_DISPLAY = "Importados/Indefinidos"
 INVALID_CITY_CODE = -1
 
 
-def format_spreadsheet_rows_as_dict(rows_table, date, state, skip_sum_cases=False):
+def format_spreadsheet_rows_as_dict(rows_table, date, state, skip_sum_cases=False, skip_sum_deaths=False):
     """
     Receives rows.Table object, a date and a brazilan UF, validates the data
     and returns tuble with 2 lists:
@@ -110,7 +110,9 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state, skip_sum_cases=Fals
         warnings.append("A checagem da soma de casos por cidade com o valor total foi desativada.")
     elif sum_cases and sum_cases != total_cases:
         validation_errors.new_error(f"A soma de casos ({sum_cases}) difere da entrada total ({total_cases}).")
-    if sum_deaths and sum_deaths != total_deaths:
+    if skip_sum_deaths:
+        warnings.append("A checagem da soma de óbitos por cidade com o valor total foi desativada.")
+    elif sum_deaths and sum_deaths != total_deaths:
         validation_errors.new_error(f"A soma de mortes ({sum_deaths}) difere da entrada total ({total_deaths}).")
 
     validation_errors.raise_if_errors()

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -12,7 +12,7 @@ UNDEFINED_DISPLAY = "Importados/Indefinidos"
 INVALID_CITY_CODE = -1
 
 
-def format_spreadsheet_rows_as_dict(rows_table, date, state):
+def format_spreadsheet_rows_as_dict(rows_table, date, state, skip_sum_cases=False):
     """
     Receives rows.Table object, a date and a brazilan UF, validates the data
     and returns tuble with 2 lists:
@@ -106,7 +106,9 @@ def format_spreadsheet_rows_as_dict(rows_table, date, state):
     if not has_undefined and len(results) > 1:
         validation_errors.new_error(f'A linha "{UNDEFINED_DISPLAY}" está faltando na planilha')
 
-    if sum_cases and sum_cases != total_cases:
+    if skip_sum_cases:
+        warnings.append("A checagem da soma de casos por cidade com o valor total foi desativada.")
+    elif sum_cases and sum_cases != total_cases:
         validation_errors.new_error(f"A soma de casos ({sum_cases}) difere da entrada total ({total_cases}).")
     if sum_deaths and sum_deaths != total_deaths:
         validation_errors.new_error(f"A soma de mortes ({sum_deaths}) difere da entrada total ({total_deaths}).")

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -269,15 +269,21 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         self.content = self.content.replace("TOTAL NO ESTADO,102,32", "TOTAL NO ESTADO,1000,32")
         file_rows = rows.import_from_csv(self.file_from_content)
 
-        with pytest.raises(SpreadsheetValidationErrors):
+        with pytest.raises(SpreadsheetValidationErrors) as execinfo:
             format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf)
+
+        exception = execinfo.value
+        assert "A soma de casos (102) difere da entrada total (1000)." in exception.error_messages
 
     def test_not_valid_if_sum_of_deaths_does_not_matches_with_total(self):
         self.content = self.content.replace("TOTAL NO ESTADO,102,32", "TOTAL NO ESTADO,102,50")
         file_rows = rows.import_from_csv(self.file_from_content)
 
-        with pytest.raises(SpreadsheetValidationErrors):
+        with pytest.raises(SpreadsheetValidationErrors) as execinfo:
             format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf)
+
+        exception = execinfo.value
+        assert "A soma de mortes (32) difere da entrada total (50)." in exception.error_messages
 
     @patch("covid19.spreadsheet_validator.validate_historical_data", Mock(return_value=[]))
     def test_do_not_check_for_totals_if_only_total_lines_data(self):

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -296,6 +296,16 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         assert results[0]["confirmed"] == 1000
 
     @patch("covid19.spreadsheet_validator.validate_historical_data", Mock(return_value=[]))
+    def test_ignore_sum_of_deaths_if_flagged(self):
+        self.content = self.content.replace("TOTAL NO ESTADO,102,32", "TOTAL NO ESTADO,102,90")
+        file_rows = rows.import_from_csv(self.file_from_content)
+
+        results, warnings = format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf, skip_sum_deaths=True)
+
+        assert "A checagem da soma de óbitos por cidade com o valor total foi desativada." in warnings
+        assert results[0]["deaths"] == 90
+
+    @patch("covid19.spreadsheet_validator.validate_historical_data", Mock(return_value=[]))
     def test_do_not_check_for_totals_if_only_total_lines_data(self):
         sample = settings.SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR-no-cities-data.csv"
         assert sample.exists()

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -286,6 +286,16 @@ class FormatSpreadsheetRowsAsDictTests(TestCase):
         assert "A soma de mortes (32) difere da entrada total (50)." in exception.error_messages
 
     @patch("covid19.spreadsheet_validator.validate_historical_data", Mock(return_value=[]))
+    def test_ignore_sum_of_cases_if_flagged(self):
+        self.content = self.content.replace("TOTAL NO ESTADO,102,32", "TOTAL NO ESTADO,1000,32")
+        file_rows = rows.import_from_csv(self.file_from_content)
+
+        results, warnings = format_spreadsheet_rows_as_dict(file_rows, self.date, self.uf, skip_sum_cases=True)
+
+        assert "A checagem da soma de casos por cidade com o valor total foi desativada." in warnings
+        assert results[0]["confirmed"] == 1000
+
+    @patch("covid19.spreadsheet_validator.validate_historical_data", Mock(return_value=[]))
     def test_do_not_check_for_totals_if_only_total_lines_data(self):
         sample = settings.SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR-no-cities-data.csv"
         assert sample.exists()


### PR DESCRIPTION
Fixes #280 

Esse PR adiciona 2 inputs como checkbox ao formulário de importação de dados. Um para desativar a soma de casos e outro para desativar a soma de óbitos. Segue print dos campos sendo apresentados logo abaixo do campo das notas do boletim:

![Screenshot from 2020-05-08 11-59-00](https://user-images.githubusercontent.com/238223/81418803-9e10b780-9123-11ea-847f-665cb2a30f04.png)
