### PR TITLE
Bump version of django-rq and fix code formatting making CI green again

### DIFF
--- a/brazil_data/cities.py
+++ b/brazil_data/cities.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from functools import lru_cache
 from itertools import groupby
-from pathlib import Path
 
 import rows
 import rows.utils

--- a/core/models.py
+++ b/core/models.py
@@ -185,11 +185,7 @@ class DynamicModelQuerySet(models.QuerySet):
                     query = SearchQuery(word, config=config)
                 else:
                     query = query & SearchQuery(word, config=config)
-            qs = (
-                qs
-                .annotate(search_rank=SearchRank(F("search_data"), query))
-                .filter(search_data=query)
-            )
+            qs = qs.annotate(search_rank=SearchRank(F("search_data"), query)).filter(search_data=query)
             # Using `qs.query.add_ordering` will APPEND ordering fields instead
             # of OVERWRITTING (as in `qs.order_by`).
             qs.query.add_ordering("-search_rank")

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -202,10 +202,10 @@ def validate_historical_data(spreadsheet):
                 f"Planilha importada somente com dados totais. Dados de cidades foram reutilizados da importação do dia {state_entry.date}."
             )
         else:
-            warnings.append(f"Planilha importada somente com dados totais.")
+            warnings.append("Planilha importada somente com dados totais.")
 
     if lower_numbers(state_entry, total_data):
-        warnings.append(f"Números de confirmados ou óbitos totais é menor que o total anterior.")
+        warnings.append("Números de confirmados ou óbitos totais é menor que o total anterior.")
 
     validation_errors.raise_if_errors()
 

--- a/covid19/stats.py
+++ b/covid19/stats.py
@@ -337,7 +337,7 @@ class Covid19Stats:
         return list(qs.order_by(*groupby_columns).values(*groupby_columns).annotate(**annotate_dict))
 
     def aggregate_epiweek(self, data, group_key="epidemiological_week"):
-        row_key = lambda row: row[group_key]
+        row_key = lambda row: row[group_key]  # noqa
         result = []
         data.sort(key=row_key)
         for epiweek, group in groupby(data, key=row_key):

--- a/covid19/tests/test_forms.py
+++ b/covid19/tests/test_forms.py
@@ -61,7 +61,7 @@ class StateSpreadsheetFormTests(Covid19DatasetTestCase):
             "boletim_urls": "http://google.com\r\n\r http://brasil.io",
             "boletim_notes": "notes",
         }
-        self.file_data = {"file": self.gen_file(f"sample.csv", valid_csv.read_bytes())}
+        self.file_data = {"file": self.gen_file("sample.csv", valid_csv.read_bytes())}
         self.user = baker.make(settings.AUTH_USER_MODEL)
         self.user.groups.add(Group.objects.get(name__endswith="Rio de Janeiro"))
         self.user.groups.add(Group.objects.get(name__endswith="Paraná"))
@@ -140,7 +140,7 @@ class StateSpreadsheetFormTests(Covid19DatasetTestCase):
             form = StateSpreadsheetForm(self.data, self.file_data)
             assert form.is_valid(), form.errors
 
-        self.file_data["file"] = self.gen_file(f"sample.txt", "col1,col2")
+        self.file_data["file"] = self.gen_file("sample.txt", "col1,col2")
         form = StateSpreadsheetForm(self.data, self.file_data)
         assert "__all__" in form.errors
 
@@ -217,7 +217,7 @@ class StateSpreadsheetFormTests(Covid19DatasetTestCase):
         valid_xls = SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR.xls"
         assert valid_xls.exists()
 
-        self.file_data["file"] = self.gen_file(f"sample.xls", valid_xls.read_bytes())
+        self.file_data["file"] = self.gen_file("sample.xls", valid_xls.read_bytes())
         form = StateSpreadsheetForm(self.data, self.file_data, user=self.user)
 
         assert form.is_valid(), form.errors
@@ -226,7 +226,7 @@ class StateSpreadsheetFormTests(Covid19DatasetTestCase):
         valid_xlsx = SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR.xlsx"
         assert valid_xlsx.exists()
 
-        self.file_data["file"] = self.gen_file(f"sample.xlsx", valid_xlsx.read_bytes())
+        self.file_data["file"] = self.gen_file("sample.xlsx", valid_xlsx.read_bytes())
         form = StateSpreadsheetForm(self.data, self.file_data, user=self.user)
 
         assert form.is_valid(), form.errors
@@ -235,7 +235,7 @@ class StateSpreadsheetFormTests(Covid19DatasetTestCase):
         valid_ods = SAMPLE_SPREADSHEETS_DATA_DIR / "sample-PR.ods"
         assert valid_ods.exists()
 
-        self.file_data["file"] = self.gen_file(f"sample.ods", valid_ods.read_bytes())
+        self.file_data["file"] = self.gen_file("sample.ods", valid_ods.read_bytes())
         form = StateSpreadsheetForm(self.data, self.file_data, user=self.user)
 
         assert form.is_valid(), form.errors
@@ -245,7 +245,7 @@ class StateSpreadsheetFormTests(Covid19DatasetTestCase):
         assert valid_xls.exists()
 
         # wrong file extension
-        self.file_data["file"] = self.gen_file(f"sample.csv", valid_xls.read_bytes())
+        self.file_data["file"] = self.gen_file("sample.csv", valid_xls.read_bytes())
         form = StateSpreadsheetForm(self.data, self.file_data, user=self.user)
 
         assert not form.is_valid()

--- a/covid19/tests/test_google_data.py
+++ b/covid19/tests/test_google_data.py
@@ -9,7 +9,6 @@ from covid19 import google_data
 
 
 class TestGoogleDataIntegration(TestCase):
-
     @skip("This test won't work with Django's DummyCache, which is enabled for development")
     def test_cache_general_spreadsheet(self):
         cache.clear()

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -569,7 +569,7 @@ class TestValidateSpreadsheetWithHistoricalData(Covid19DatasetTestCase):
         undefined_name = self.undefined_data["city"]
         expected = [
             f"Números de confirmados ou óbitos em {undefined_name} é menor que o anterior.",
-            f"Números de confirmados ou óbitos totais é menor que o total anterior.",
+            "Números de confirmados ou óbitos totais é menor que o total anterior.",
         ]
         warnings = validate_historical_data(self.spreadsheet)
 

--- a/covid19/views.py
+++ b/covid19/views.py
@@ -61,11 +61,7 @@ def clean_weekly_data(data, skip=0, diff_days=-14):
     now = datetime.datetime.now()
     today = datetime.date(now.year, now.month, now.day)
     _, until_epiweek = get_epiweek(today + datetime.timedelta(days=diff_days))
-    return [
-        row
-        for index, row in enumerate(data)
-        if index >= skip and row["epidemiological_week"] < until_epiweek
-    ]
+    return [row for index, row in enumerate(data) if index >= skip and row["epidemiological_week"] < until_epiweek]
 
 
 def historical_data(request, period):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-minio-storage==0.3.7
 django-naomi
 django-recaptcha
 django-redis
-django-rq==2.3.1
+django-rq==2.3.2
 django-storages==1.9.1
 django>=2.0
 djangorestframework


### PR DESCRIPTION
Running `python manage.py migrate` locally with both Python 3.7 and
Python 3.8 was raises the following exception:

```
File "[...]/django_rq/templatetags/django_rq.py", line 4, in <module>
    from rq.exceptions import UnpickleError
ImportError: cannot import name 'UnpickleError' from 'rq.exceptions' ([...]/rq/exceptions.py)
```

The issue was on `django-rq` package due incompatibility with `rq` lib.
It was fixed by this commit:

https://github.com/rq/django-rq/commit/9f7dbe32623b085ea85799fc20dc0fb36b9903ab

And released on 2.3.2 version:

https://github.com/rq/django-rq/commit/9f7dbe32623b085ea85799fc20dc0fb36b9903ab

This change sets `django-rq` version as 2.3.2.