### PR TITLE
add img[alt] and a[title]

### DIFF
--- a/brasilio_auth/templates/brasilio_auth/user_creation_form.html
+++ b/brasilio_auth/templates/brasilio_auth/user_creation_form.html
@@ -40,7 +40,7 @@
       <p class="valign-wrapper">
         Saiba das nossas novidades rapidamente:
         &nbsp;
-        <a href="https://t.me/brasil_io">
+        <a href="https://t.me/brasil_io" title="Ir ao Telegram do Brasil.IO">
           <img src="{% static 'img/logo-telegram.png' %}" style="height: 2em" alt="Logo Telegram">
         </a>
         &nbsp;

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -38,10 +38,10 @@
   <body>
     <nav>
         <div class="nav-wrapper indigo">
-          <a href="/" class="brand-logo">
-            <img src="{% static 'img/logo/logo_br-io_fundo-escuro.png' %}" style="max-height:40px;margin-left: 20px; margin-top: 10px;">
+          <a href="/" class="brand-logo" title="Ir à página inicial">
+            <img src="{% static 'img/logo/logo_br-io_fundo-escuro.png' %}" style="max-height:40px;margin-left: 20px; margin-top: 10px;" alt="Logo da Brasil.IO">
           </a>
-            <a href="#" data-target="mobile-demo" class="sidenav-trigger"><i class="material-icons">menu</i></a>
+            <a href="#" data-target="mobile-demo" class="sidenav-trigger" title="Menu"><i class="material-icons">menu</i></a>
             <ul class="right hide-on-med-and-down">
               {% include 'menu.html' with id_prefix='desktop' %}
             </ul>
@@ -96,8 +96,8 @@
                     </label>
                   </div>
                   <div class="col m4">
-                    <a class="valign-wrapper" href="https://t.me/brasil_io">
-                      <img style="height: 2em" src="{% static 'img/logo-telegram.png' %}" alt="Logo Telgram">
+                    <a class="valign-wrapper" href="https://t.me/brasil_io" title="Ir ao Telegram do Brasil.IO">
+                      <img style="height: 2em" src="{% static 'img/logo-telegram.png' %}" alt="Logo Telegram">
                       &nbsp;
                       t.me/brasil_io
                     </a>
@@ -113,7 +113,7 @@
         <div class="section indigo-text text-lighten-5" style="padding-top: 0 !important;">
           <p>
             O <b>Brasil.IO</b> é mantido com muito carinho por
-            <a href="https://twitter.com/turicas">Álvaro Justen</a> e
+            <a href="https://twitter.com/turicas" title="Twitter do Álvaro Justen">Álvaro Justen</a> e
             <a href="{% url 'core:contributors' %}">contribuidores</a>.
           </p>
         </div>

--- a/core/templates/collaborate.html
+++ b/core/templates/collaborate.html
@@ -52,7 +52,7 @@
       disponíveis;
     </li>
     <li>
-      <a href="{% url 'core:donate' %}"><b>Doando recorrentemente</b></a>.
+      <a href="{% url 'core:donate' %}" title="Faça uma doação!"><b>Doando recorrentemente</b></a>.
     </li>
   </ol>
 

--- a/core/templates/contact.html
+++ b/core/templates/contact.html
@@ -15,7 +15,7 @@
   <p>
     Preencha o formulário abaixo para entrar em contato conosco ou envie
     diretamente um email a
-    <a href="mailto:contato@brasil.io">contato@brasil.io</a>.
+    <a href="mailto:contato@brasil.io" title="Entre em contato via e-mail">contato@brasil.io</a>.
   </p>
   <p>
     Caso queira ter uma conversa mais longa e colaborar mais ativamente com o

--- a/core/templates/contas-gratuitas.html
+++ b/core/templates/contas-gratuitas.html
@@ -7,18 +7,18 @@
           Acesso a Páginas Especiais
         </div>
         <p>
-          As <a href="{% url 'core:specials' %}">páginas especiais</a> são restritas
+          As <a href="{% url 'core:specials' %}" title="Páginas restritas">páginas especiais</a> são restritas
           a quem possui uma conta no <a
-            href="https://brasil.io/">Brasil.IO</a>. <b>Durante nossa fase BETA
+            href="https://brasil.io/" title="Brasil.IO">Brasil.IO</a>. <b>Durante nossa fase BETA
             as contas serão todas gratuitas</b> - após esse período será
           necessária a assinatura do site para acessar todas as páginas
           restritas.
         </p>
         <p>
-          O <a href="https://brasil.io/">Brasil.IO</a> é desenvolvido de
+          O <a href="https://brasil.io/" title="Brasil.IO">Brasil.IO</a> é desenvolvido de
           maneira colaborativa e voluntária. <b>Você pode contribuir</b> <a
-            href="{% url 'core:donate' %}">fazendo uma doação</a> ou <a
-            href="{% url 'core:collaborate' %}">de outras formas</a>.
+            href="{% url 'core:donate' %}" title="Faça uma doação!">fazendo uma doação</a> ou <a
+            href="{% url 'core:collaborate' %}" title="Colabore!">de outras formas</a>.
         </p>
       </div>
     </div>

--- a/core/templates/contributors.html
+++ b/core/templates/contributors.html
@@ -12,31 +12,31 @@
         código</i> com o projeto nos vários repositórios de código que
       temos no GitHub (tanto da plataforma, quanto dos programas de captura de
       dados). Além disso, também contribui com a plataforma <a
-        href="https://apoia.se/brasilio">quem doa em nossa campanha de
+        href="https://apoia.se/brasilio" title="Apoie nossa campanha">quem doa em nossa campanha de
         financiamento coletivo</a> e também
       voluntários que desempenham outras tarefas (como <a
-        href="https://blog.brasil.io/2020/03/23/dados-coronavirus-por-municipio-mais-atualizados/">os
+        href="https://blog.brasil.io/2020/03/23/dados-coronavirus-por-municipio-mais-atualizados/" title="Veja nossos voluntários">os
         voluntários que coletam dados do COVID19</a>).
     </p>
 
       {% for contributor in contributors %}
       <div class="col s12 m3 m-t-5 m-b-10">
         <span class="fa-stack fa-4x text-center">
-          <a href="http://github.com/{{ contributor.login }}" target="_blank">
-            <img class="circle responsive-img" src="{{ contributor.avatar_url }}" alt="">
+          <a href="http://github.com/{{ contributor.login }}" target="_blank" title="Visitar @{{ contributor.login }}">
+            <img class="circle responsive-img" src="{{ contributor.avatar_url }}" alt="Imagem de {{ contributor.login }}">
           </a>
         </span>
-        <h6> <a href="{{  contributor.html_url }}">@{{ contributor.login }}</a> </h6>
+        <h6> <a href="{{  contributor.html_url }}" title="Visitar página do contribuidor">@{{ contributor.login }}</a> </h6>
         <span class="social-buttons-container text-center">
           <ul class="social-buttons">
             <li>
-              <a href="http://github.com/{{ contributor.login }}" target="_blank">
+              <a href="http://github.com/{{ contributor.login }}" title="Visitar @{{ contributor.login }}" target="_blank">
                 <i class="fa fa-github" aria-hidden="true"></i>
               </a>
             </li>
             {% if contributor.blog %}
             <li>
-              <a href="{{ contributor.blog }}" target="_blank">
+              <a href="{{ contributor.blog }}" title="Visitar blog" target="_blank">
                 <i class="fa fa-link" aria-hidden="true"></i>
               </a>
             </li>

--- a/core/templates/data-table.html
+++ b/core/templates/data-table.html
@@ -22,7 +22,7 @@
   <tr>
     {% for field in fields %}{% if field.show_on_frontend %}{% with value=row|getattribute:field %}
     {% if field.link_template and value %}
-    <td><a href="{{ field.link_template|render:row }}"> {{ value }} </a></td>
+    <td><a href="{{ field.link_template|render:row }}" title="Ver mais"> {{ value }} </a></td>
     {% else %}
     <td>{{ value|default_if_none:'' }}</td>
     {% endif %}

--- a/core/templates/dataset-card.html
+++ b/core/templates/dataset-card.html
@@ -6,7 +6,7 @@
       <div class="card-content">
         <span class="card-title activator grey-text text-darken-4">
           <i class="material-icons fa-1x left">{{ dataset.icon }}</i>
-            <a href="{% url 'core:dataset-detail' dataset.slug %}">
+            <a href="{% url 'core:dataset-detail' dataset.slug %}" title="Ver mais">
               {{ dataset.name }}
             </a>
         </span>
@@ -18,7 +18,7 @@
           Tabelas:
           {% for table in dataset.tables %}
           {% spaceless %}
-          <a href="{% url 'core:dataset-table-detail' dataset.slug table.name %}">
+          <a href="{% url 'core:dataset-table-detail' dataset.slug table.name %}" title="Ver mais">
             {% if table.default %}<b>{{ table.name }}</b>
             {% else %}
             {{ table.name }}

--- a/core/templates/dataset-detail.html
+++ b/core/templates/dataset-detail.html
@@ -14,22 +14,22 @@
     </p>
     <ul>
       <li>
-        Fonte original: <a href="{{ dataset.source_url }}">{{ dataset.source_name }}</a>
+        Fonte original: <a href="{{ dataset.source_url }}" title="Ver fonte original">{{ dataset.source_name }}</a>
       </li>
       <li>
-        Libertado por: <a href="{{ dataset.author_url }}">{{ dataset.author_name }}</a>
+        Libertado por: <a href="{{ dataset.author_url }}" title="Ver liberador">{{ dataset.author_name }}</a>
       </li>
       <li>
-        Código-fonte: <a href="{{ dataset.code_url }}">{{ dataset.code_url }}</a>
+        Código-fonte: <a href="{{ dataset.code_url }}" title="Ver código-fonte">{{ dataset.code_url }}</a>
       </li>
       <li>
-        Licença: <a href="{{ dataset.license_url }}">{{ dataset.license_name }}</a>
+        Licença: <a href="{{ dataset.license_url }}" title="Ver licença">{{ dataset.license_name }}</a>
       </li>
       {% if dataset.link_set.all %}
       <li>
         Links relacionados:
         {% for link in dataset.link_set.all %}
-          <a href="{{ link.url }}" target="_blank">{{ link.title }}</a>{% if not forloop.last %}, {% endif %}
+          <a href="{{ link.url }}" title="Ver mais" target="_blank">{{ link.title }}</a>{% if not forloop.last %}, {% endif %}
         {% endfor %}
       </li>
       {% endif %}

--- a/core/templates/dataset-list.html
+++ b/core/templates/dataset-list.html
@@ -33,7 +33,7 @@
   {% endfor %}
 
   <div class="col s12 m4 m-t-15">
-    <a href="{% url 'core:dataset-suggestion' %}">
+    <a href="{% url 'core:dataset-suggestion' %}" title="Ver dataset">
       <div class="card horizontal small">
         <div class="card-stacked">
           <div class="card-content">
@@ -47,7 +47,7 @@
           </div>
           <div class="card-action indigo-text text-accent-4">
             <p>
-              <a href="{% url 'core:dataset-suggestion' %}"> Sugerir </a>
+              <a href="{% url 'core:dataset-suggestion' %}" title="Sugerir"> Sugerir </a>
             </p>
           </div>
         </div>

--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -102,7 +102,7 @@
     {% endfor %}
 
     <div class="row text-center">
-      <a class="btn btn-ptc btn-md waves-effect waves-light" href="{% url 'core:dataset-list' %}" role="button">
+      <a class="btn btn-ptc btn-md waves-effect waves-light" href="{% url 'core:dataset-list' %}" title="Ver Todos Datasets" role="button">
         Ver Todos Datasets
       </a>
     <div>

--- a/core/templates/manifesto.html
+++ b/core/templates/manifesto.html
@@ -7,7 +7,7 @@
 
     <h5>O Problema</h5>
     <p>
-        Após a criação da <a href="http://www.planalto.gov.br/ccivil_03/_Ato2011-2014/2011/Lei/L12527.htm">
+        Após a criação da <a href="http://www.planalto.gov.br/ccivil_03/_Ato2011-2014/2011/Lei/L12527.htm" title="Ver Lei de Acesso à Informação">
             Lei de Acesso à Informação</a>, todas as informações produzidas ou
         custodiadas pelo poder público são públicas e portanto, disponíveis a todos
         os cidadãos, exceto aquelas que são sigilosas por lei. Contudo, mesmo que a
@@ -54,7 +54,7 @@
         formato amigável. Muitos jornalistas, cientistas sociais, advogados, e
         profissionais de diversas outras áreas precisam contratar desenvolvedores
         para conseguir esses dados em um formato que eles consigam mexer ou
-        preferem <a href="http://journalismcourses.org/PJ1020.html"> aprender a
+        preferem <a href="http://journalismcourses.org/PJ1020.html" title="Ver artigo"> aprender a
             programar</a> para resolver esse problema, porém, acabam levando mais
         tempo para atingir o objetivo principal: analisar os dados.
     </p>
@@ -75,20 +75,20 @@
         <ol>
             <li><b>Formato</b> (qualidade técnica)</li>
             <ul>
-                <li>Exemplo: Boletim de balneabilidade em PDF <a href="https://brasil.io/dataset/balneabilidade-bahia/balneabilidade">(INEMA/BA)</a></li>
+                <li>Exemplo: Boletim de balneabilidade em PDF <a href="https://brasil.io/dataset/balneabilidade-bahia/balneabilidade" title="Ver Boletim de balneabilidade ">(INEMA/BA)</a></li>
             </ul>
             <li><b>Dispersão</b></li>
             <ul>
-                <li>Exemplo: Filiações partidárias em 945 ZIPs com CSVs <a href="https://brasil.io/dataset/eleicoes-brasil/filiados">(TSE)</a></li>
+                <li>Exemplo: Filiações partidárias em 945 ZIPs com CSVs <a href="https://brasil.io/dataset/eleicoes-brasil/filiados" title="Ver dataset">(TSE)</a></li>
             </ul>
             <li><b>Quantidade</b> de dados</li>
             <ul>
-                <li>Exemplo: 18 milhões de sócios <a href="https://brasil.io/dataset/socios-brasil/socios">(Receita
+                <li>Exemplo: 18 milhões de sócios <a href="https://brasil.io/dataset/socios-brasil/socios" title="Ver dataset">(Receita
                         Federal)</a></li>
             </ul>
             <li><b>Domínio</b> da área</li>
             <ul>
-                <li>Exemplo: o que é <i>unidade eleitoral</i>? <a href="https://brasil.io/dataset/eleicoes-brasil/votacoes">(TSE)</a></li>
+                <li>Exemplo: o que é <i>unidade eleitoral</i>? <a href="https://brasil.io/dataset/eleicoes-brasil/votacoes" title="Ver dataset">(TSE)</a></li>
             </ul>
         </ol>
     </p>
@@ -99,10 +99,10 @@
         e temos como valores principais a transparência e colaboração. Dessa
         maneira, tudo o que produzimos pode ser verificável, pois além de
         disponibilizarmos os dados em formatos abertos, nosso
-        <a href="https://pt.wikipedia.org/wiki/Software_livre">software é livre</a>
+        <a href="https://pt.wikipedia.org/wiki/Software_livre" title="Ver artigo">software é livre</a>
         e produzimos tudo isso de maneira colaborativa. Entre
         <a href="https://chat.brasil.io/">em nosso chat</a> para saber como
-        colaborar ou em <a href="https://github.com/turicas/brasil.io">nosso
+        colaborar ou em <a href="https://github.com/turicas/brasil.io" title="Acesse nosso github">nosso
             repositório de código no GitHub</a>.
     </p>
 
@@ -132,7 +132,7 @@
             </li>
             <li>
                 Projetos de inovação cívica e controle social, como, por exemplo, a
-                <a href="https://serenata.ai/">Operação Serenata de Amor</a>.
+                <a href="https://serenata.ai/" title="Acesse Operação Serenata de Amor">Operação Serenata de Amor</a>.
                 A centralização dessas informações em um formato acessível torna viável
                 projetos que sofreriam muitas dificuldades técnicas sem esses dados
                 disponibilizados dessa maneira.

--- a/core/templates/menu.html
+++ b/core/templates/menu.html
@@ -7,7 +7,7 @@
 </a></li>
 <ul id="{{id_prefix}}_authenticated-dropdown" class="dropdown-content">
   {% if is_covid19_contributor %}
-  <li><a href="{% url 'admin:covid19_statespreadsheet_changelist' %}">Importação Covid-19</a></li>
+  <li><a href="{% url 'admin:covid19_statespreadsheet_changelist' %}" title="Ver Importação Covid-19">Importação Covid-19</a></li>
   {% endif %}
   <li><a href="{% url 'brasilio_auth:logout' %}">Logout</a></li>
 </ul>

--- a/core/templates/specials/index.html
+++ b/core/templates/specials/index.html
@@ -30,28 +30,28 @@
         por nome ou documento</a> o visitante poderá acessar um dossiê do
       documento (CPF ou CNPJ), onde serão mostradas ocorrências em vários
       datasets disponíveis no portal. Exemplo:
-      <a href="{% url 'core:special-document-detail' document='75095679000149' %}">
+      <a href="{% url 'core:special-document-detail' document='75095679000149' %}" title="Ver Universidade Federal do Paraná">
         Universidade Federal do Paraná
       </a>.
     </li>
     <li>
-      <a href="{% url 'core:special-trace-path' %}">Caminhos nas relações
+      <a href="{% url 'core:special-trace-path' %}" title="Ver Caminhos nas relações pessoais (física e/ou jurídica)">Caminhos nas relações
         pessoais (física e/ou jurídica)</a> - a partir de duas pessoas (físicas
       e/ou jurídicas) o visitante conseguirá verificar a existência de uma
       relação de sociedade, independente do nível (exemplo: A é sócio da
       empresa X, que é sócia da empresa Y e tem como sócio também Z - dessa
       forma, A é indiretamente sócio de Z). Exemplo real:
-      <a href="{% url 'core:special-trace-path' %}?origin_type=pessoa-juridica&origin_identifier=15102288000182&destination_type=pessoa-juridica&destination_identifier=61065751000180">qual a
+      <a href="{% url 'core:special-trace-path' %}?origin_type=pessoa-juridica&origin_identifier=15102288000182&destination_type=pessoa-juridica&destination_identifier=61065751000180" title="Ver ligação entre Rossi Residencial SA e a Construtora Norberto Odebrecht">qual a
         ligação entre a Rossi Residencial SA e a Construtora Norberto Odebrecht
       SA?</a>
     </li>
     <li>
-      <a href="{% url 'core:special-company-groups' %}">Grupos Empresariais de uma empresa</a> -
+      <a href="{% url 'core:special-company-groups' %}" title="Ver Grupos Empresariais de uma empresa">Grupos Empresariais de uma empresa</a> -
       Com o CNPJ de uma empresa, podemos listar a qual ou quais grupos empresariais
       a empresa pertence. Um grupo empresarial é determinado através das relações
       de sociedades entre empresas (exemplo: a empresa A é sócia de B que também tem
       como sócia a empresa C - dessa forma, B pertence aos grupos empresariais de A e C).
-      Exemplo real: <a href="{% url 'core:special-company-groups' %}?identifier=24657281000123">qual
+      Exemplo real: <a href="{% url 'core:special-company-groups' %}?identifier=24657281000123" title="Veja os grupos empresariais da empresa Passos Construções SPE LTDA">qual
       os grupos empresariais da empresa Passos Construções SPE LTDA?</a>
     </li>
   </ul>

--- a/core/templates/specials/trace-path.html
+++ b/core/templates/specials/trace-path.html
@@ -28,9 +28,9 @@
   {% for node in nodes %}
     <div>
       {% if node.tipo == 'PessoaJuridica' or node.tipo == 'EmpresaMae' %}
-      <a href="{% url 'core:special-document-detail' document=node.cnpj %}">{{ node.nome }}</a>
+      <a href="{% url 'core:special-document-detail' document=node.cnpj %}" title="Ver documento">{{ node.nome }}</a>
       {% else %}
-      <a href="{% url 'core:dataset-table-detail' 'socios-brasil' 'socios' %}?nome_socio={{ node.nome }}">{{ node.nome }}</a>
+      <a href="{% url 'core:dataset-table-detail' 'socios-brasil' 'socios' %}?nome_socio={{ node.nome }}" title="Ver documento">{{ node.nome }}</a>
       {% endif %}
     </div>
     {% endfor %}

--- a/covid19/static/js/covid19-chart.js
+++ b/covid19/static/js/covid19-chart.js
@@ -175,7 +175,7 @@ jQuery(document).ready(function(){
   }
   var deathsTitle = `Causas de óbitos por semana epidemiológica${titleAppend}`;
   var deathsCompareTitle = `Óbitos novos por semana epidemiológica 2019 vs 2020${titleAppend}`;
-  var deathsSourceLink = 'Fonte: <a href="https://transparencia.registrocivil.org.br/registral-covid">Registro Civil</a>.';
+  var deathsSourceLink = 'Fonte: <a href="https://transparencia.registrocivil.org.br/registral-covid" title="Ver fonte">Registro Civil</a>.';
   var deathsSourceNote = " *Nota: as últimas 2 semanas não estão representadas pois os dados estão em processamento pelos cartórios.";
   var deathsSource = deathsSourceLink + deathsSourceNote;
   var deathsGroupSource = deathsSourceLink + " Grupos: COVID-19 (suspeita ou confirmação por COVID-19), Outras respiratórias (pneumonia + insuf. resp. + SRAG), Outras (septicemia + indeterminada + outras causas naturais não externas)." + deathsSourceNote;

--- a/covid19/static/js/covid19-map.js
+++ b/covid19/static/js/covid19-map.js
@@ -169,7 +169,7 @@ function updateMap() {
     notesControl.onAdd = function (map) {
       var div = L.DomUtil.create("div", "info legend");
       div.innerHTML = 'Fonte: Secretarias Estaduais de Saúde'
-      div.innerHTML += '<br>Coleta e análise: <a href="https://brasil.io/">Brasil.IO</a>';
+      div.innerHTML += '<br>Coleta e análise: <a href="https://brasil.io/" title="Brasil.IO">Brasil.IO</a>';
       return div;
     };
     notesControl.addTo(map);

--- a/covid19/templates/admin/covid19_add_form.html
+++ b/covid19/templates/admin/covid19_add_form.html
@@ -4,7 +4,7 @@
 {% block object-tools %}
   <ul class="object-tools">
     {% for state in allowed_states %}
-    <li><a href="{% url 'admin:sample_covid_spreadsheet' state.acronym %}">Modelo {{ state.acronym }}</a></li>
+    <li><a href="{% url 'admin:sample_covid_spreadsheet' state.acronym %}" title="Ver Modelo {{ state.acronym }}">Modelo {{ state.acronym }}</a></li>
     {% endfor %}
   </ul>
 {% endblock %}

--- a/covid19/templates/covid19-text.html
+++ b/covid19/templates/covid19-text.html
@@ -1,5 +1,5 @@
 <p>
-  Graças a uma força-tarefa de <a href="{% url 'covid19:volunteers' %}">40
+  Graças a uma força-tarefa de <a href="{% url 'covid19:volunteers' %}" title="Ver voluntários">40
     voluntários</a> que, diariamente, compilam boletins epidemiológicos das 27
   Secretarias Estaduais de Saúde, disponibilizamos uma base de dados
   com a série histórica de casos e óbitos confirmados por município. Embora

--- a/covid19/templates/dashboard.html
+++ b/covid19/templates/dashboard.html
@@ -122,7 +122,7 @@
         <tr>
           <td data-search="{{ row.date|date:"d/m/Y" }}" data-order="{% localize off %}{{ row.date_str }}{% endlocalize %}"> {{ row.date|date:"d/m/Y" }} </td>
           <td data-search="{{ row.city_str }} {{ row.city }}" data-order="{{ row.city_str }}"> {{ row.city }} </td>
-          {% if not state %}<td data-search="{{ row.state }}"> <a href="{% url 'covid19:dashboard' row.state %}">{{ row.state }}</a> </td>{% endif %}
+          {% if not state %}<td data-search="{{ row.state }}"> <a href="{% url 'covid19:dashboard' row.state %}" title="{{ row.state }}">{{ row.state }}</a> </td>{% endif %}
           <td data-order="{% localize off %}{{ row.confirmed }}{% endlocalize %}"> {{ row.confirmed }} </td>
           <td data-order="{% localize off %}{{ row.confirmed_per_100k_inhabitants }}{% endlocalize %}"> {{ row.confirmed_per_100k_inhabitants|floatformat:2 }} </td>
           <td data-order="{% localize off %}{{ row.deaths }}{% endlocalize %}"> {{ row.deaths }} </td>

--- a/covid19/templates/volunteers.html
+++ b/covid19/templates/volunteers.html
@@ -19,11 +19,11 @@
     {% for volunteer in volunteers %}
     <div class="col s12 m3 m-t-5 m-b-10">
       <span class="fa-stack fa-4x text-center">
-        <a href="{{ volunteer.personal_url }}" target="_blank">
-          <img class="circle responsive-img" src="{{ volunteer.avatar_url }}" alt="">
+        <a href="{{ volunteer.personal_url }}" target="_blank" title="Visitar perfil de {{ volunteer.name }}">
+          <img class="circle responsive-img" src="{{ volunteer.avatar_url }}" alt="Imagem de {{ volunteer.name }}">
         </a>
       </span>
-      <h6> <a href="{{  volunteer.personal_url }}">{{ volunteer.name }}</a> </h6>
+      <h6> <a href="{{  volunteer.personal_url }}" title="Visitar perfil de {{ volunteer.name }}">{{ volunteer.name }}</a> </h6>
     </div>
     {% endfor %}
   </div>
@@ -31,8 +31,8 @@
   <div class="row text-center m-t-5">
     <p>
       Além das pessoas que contribuem na coleta de dados, veja também as que <a
-        href="https://apoia.se/brasilio"><b>contribuem financeiramente</b></a>
-      e as que <a href="{% url 'core:contributors' %}"><b>contribuem com
+        href="https://apoia.se/brasilio" title="Apoie o Brasil.IO"><b>contribuem financeiramente</b></a>
+      e as que <a href="{% url 'core:contributors' %}" title="Nossos contribuidores"><b>contribuem com
           código</b></a>. Diversas outras pessoas também colaboram com
       <b>informações, sugestões, correções e na divulgação dos dados</b>.
     </p>

--- a/data-server/templates/list.html
+++ b/data-server/templates/list.html
@@ -23,8 +23,8 @@
   <body>
    <nav>
     <div class="nav-wrapper indigo">
-      <a href="https://brasil.io/" class="brand-logo">
-        <img src="https://data.brasil.io/brasilio-static/img/logo/logo_br-io_fundo-escuro.png" style="max-height:40px;margin-left: 20px; margin-top: 10px;">
+      <a href="https://brasil.io/" class="brand-logo" title="Ir ao Telegram do Brasil.IO">
+        <img src="https://data.brasil.io/brasilio-static/img/logo/logo_br-io_fundo-escuro.png" style="max-height:40px;margin-left: 20px; margin-top: 10px;" alt="Logo do Brasil.IO">
       </a>
     </div>
     </nav>
@@ -43,7 +43,7 @@
                   Colabore!
                 </div>
                 <p>
-                  O <a href="https://brasil.io/">Brasil.IO</a> tem como
+                  O <a href="https://brasil.io/" title="Brasil.IO">Brasil.IO</a> tem como
                   objetivo facilitar o acesso a dados públicos brasileiros. O
                   projeto é desenvolvido de forma colaborativa, <a
                     href="https://github.com/turicas/brasil.io">todo o código
@@ -72,7 +72,7 @@
               {% for file in file_list %}
               <tr>
                 <td>
-                  <a href="../{{ file.filename }}">{{ file.filename }}</a>
+                  <a href="../{{ file.filename }}" title="Baixar arquivo">{{ file.filename }}</a>
                 </td>
                 <td> {{ file.size }} </td>
                 <td> {{ file.sha512sum }} </td>


### PR DESCRIPTION
## Motivo da PR
Temos uma iniciativa de melhorias de frontend, iniciando por melhor acessibilidade e apoio nos links e imagens.

## O que faz?
Atribui a propriedade `alt` para as imagens e `title` para links.
Fixes -> #296 

> Peço por gentileza, que façam uma leitura e opinem minha forma de atribuir os `title` para os links, busquei uma forma mais ativa de indicação: Veja, Acesse, Apoie!... ao invés de apenas replicar o texto do link. Posso mudar a forma de ação!