### PR TITLE
Altera algumas cores para garantir no minimo contraste AA

### DIFF
--- a/static/css/application.css
+++ b/static/css/application.css
@@ -83,6 +83,9 @@ body {
 .footer {
   text-align: center;
 }
+.footer.indigo a {
+  color: #00a2ec;
+}
 
 .email-newsletter {
   height: 2em !important;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -113,7 +113,6 @@
 }
 
 /* Colors */
-
 .dark-blue {
   color: #3f51b5 !important;
 }
@@ -123,13 +122,29 @@
 }
 
 .btn-dark-blue {
-  background-color: #3f51b5;
+  background-color: #3f51b5 !important;
   color: #fff !important;
 }
-
 .btn-dark-blue:hover {
-  background-color: #fff ;
+  background-color: #fff !important;
   color: #1A237E !important;
+}
+
+/* Closest AA compatible for color contrast (a11y) */
+a {
+  color: #007db6;
+}
+.btn, .btn-large, .btn-small, .btn-floating {
+  background-color: #008376;
+}
+.btn:hover, .btn-large:hover, .btn-small:hover, .btn-floating:hover {
+  background-color: #00897b;
+}
+.teal-text {
+  color: #008376 !important;
+}
+.dropdown-content li > a, .dropdown-content li > span {
+  color: #008376;
 }
 
 .email-newsletter {


### PR DESCRIPTION
A [Materialize.css](https://materializecss.com) tem alguns problemas chatinhos de [contraste compatíveis com acessibilidade](https://developer.mozilla.org/pt-BR/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast?utm_source=devtools&utm_medium=a11y-panel-checks-color-contrast). Usando inspetores de acessibilidade como o [Wave](https://wave.webaim.org/) e o check do Firefox dá pra ir achando alguns casos:

- A classe `.btn`, com o fundo teal (`#009688`);
- A classe `.teal-text` e os links dos dropdowns (tbm `#009688`);
- Os links de maneira geral (`#039be5`);
- Os links no footer (que é muito escuro praquela cor);

Então usando essa [ferramenta aqui](https://color.review/) eu busquei cores que pelo menos garantissem o nível AA de contraste textual. Posso ter deixado passar alguma coisa, já que me aventurei pouco no ambiente dev, mas acho que deu pra cobrir os casos mais gritantes que vi pelo inspetor da Wave. Segue um screenshot da tela inicial:

![Screenshot_2020-06-09 Home - Brasil IO](https://user-images.githubusercontent.com/1184874/84219207-5bd1f180-aaa6-11ea-9c20-adc0785ec08e.png)
