### PR TITLE
Novo comando para corrigir entradas por cidade para planilhas só com total

### DIFF
--- a/covid19/management/commands/fix_covid19_past_total_imports.py
+++ b/covid19/management/commands/fix_covid19_past_total_imports.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+
+from covid19.models import StateSpreadsheet
+
+
+class Command(BaseCommand):
+    help = "Fix previous inconsisted cancelled spreadsheets"
+
+    def handle(self, *args, **kwargs):
+        only_with_total_qs = StateSpreadsheet.objects.filter(
+            data__warnings__icontains='Planilha importada somente com dados totais'
+        ).exclude(status=StateSpreadsheet.CHECK_FAILED)
+
+        updated = 0
+        for sp in only_with_total_qs:
+            previous_deployed = StateSpreadsheet.objects.exclude(id=sp.id).most_recent_deployed(sp.state, sp.date)
+            if not previous_deployed:
+                continue
+
+            if sp.table_data_by_city != previous_deployed.table_data_by_city:
+                updated += 1
+                print(f"Planilha ({sp.id}) somente com totais para {sp.state} - {sp.date}.", end=" ")
+                print(f"Corrigindo os números para as cidades usando os dados da planilha anterior.")
+
+                sp.table_data = [sp.get_total_data()] + list(previous_deployed.table_data_by_city.values())
+                sp.save()
+
+        print("------")
+        print(f"{only_with_total_qs.count()} planilhas somente com totais.\n{updated} tiveram os dados para múnicipios atualizados.")

--- a/covid19/management/commands/fix_covid19_past_total_imports.py
+++ b/covid19/management/commands/fix_covid19_past_total_imports.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         only_with_total_qs = StateSpreadsheet.objects.filter(
             data__warnings__icontains='Planilha importada somente com dados totais'
-        ).exclude(status=StateSpreadsheet.CHECK_FAILED)
+        )
 
         updated = 0
         for sp in only_with_total_qs:

--- a/covid19/management/commands/fix_covid19_past_total_imports.py
+++ b/covid19/management/commands/fix_covid19_past_total_imports.py
@@ -21,8 +21,8 @@ class Command(BaseCommand):
 
             if sp.table_data_by_city != previous_deployed.table_data_by_city:
                 updated += 1
-                print(f"Planilha ({sp.id}) somente com totais para {sp.state} - {sp.date}.", end=" ")
-                print(f"Corrigindo os números para as cidades usando os dados da planilha anterior.")
+                print(f"Planilha ({sp.id} em {sp.created_at}) somente com totais para {sp.state} - {sp.date}.", end=" ")
+                print(f"Usando números das cidades usando a planilha anterior ({previous_deployed.id} e {previous_deployed.created_at}).")
 
                 sp.table_data = [sp.get_total_data()] + list(previous_deployed.table_data_by_city.values())
                 sp.save()

--- a/covid19/management/commands/fix_covid19_past_total_imports.py
+++ b/covid19/management/commands/fix_covid19_past_total_imports.py
@@ -13,7 +13,9 @@ class Command(BaseCommand):
 
         updated = 0
         for sp in only_with_total_qs:
-            previous_deployed = StateSpreadsheet.objects.exclude(id=sp.id).most_recent_deployed(sp.state, sp.date)
+            previous_deployed = StateSpreadsheet.objects.exclude(
+                id__gte=sp.id,
+            ).most_recent_deployed(sp.state, sp.date)
             if not previous_deployed:
                 continue
 

--- a/covid19/management/commands/update_state_totals.py
+++ b/covid19/management/commands/update_state_totals.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import logging
 import os
 import socket
 
@@ -59,7 +58,7 @@ class Command(BaseCommand):
             confirmed = row.confirmed
             deaths = row.deaths
 
-            recent_deploy = StateSpreadsheet.objects.filter(date=date).deployable_for_state(state).first()
+            recent_deploy = StateSpreadsheet.objects.most_recent_deployed(state, date)
             if recent_deploy:
                 data = recent_deploy.get_total_data()
 

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -57,6 +57,12 @@ class StateSpreadsheetQuerySet(models.QuerySet):
             qs = qs.distinct("date")
         return qs
 
+    def most_recent_deployed(self, state, date=None):
+        qs = self.deployable_for_state(state)
+        if date:
+            qs = qs.filter(date__lte=date)
+        return qs.first()
+
 
 def default_data_json():
     return {


### PR DESCRIPTION
@turicas para rodar o comando basta executar:

```
$ dokku brasilio-web run python manage.py fix_covid19_past_total_imports
```

Segue o log do meu console local após rodar o comando usando o dump que estava em `covid19_statespreadsheet.csv`:

```
Planilha (622) somente com totais para PE - 2020-05-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (634) somente com totais para PE - 2020-05-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1179) somente com totais para PE - 2020-05-15. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (785) somente com totais para PE - 2020-05-09. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1097) somente com totais para PE - 2020-05-14. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (871) somente com totais para PE - 2020-05-10. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (786) somente com totais para PE - 2020-05-09. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (844) somente com totais para PE - 2020-05-10. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (986) somente com totais para PE - 2020-05-12. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1061) somente com totais para PE - 2020-05-13. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (911) somente com totais para PE - 2020-05-11. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (922) somente com totais para PE - 2020-05-11. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1205) somente com totais para PE - 2020-05-16. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1003) somente com totais para PE - 2020-05-12. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1161) somente com totais para PE - 2020-05-15. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1109) somente com totais para PE - 2020-05-14. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1058) somente com totais para PE - 2020-05-13. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1229) somente com totais para PE - 2020-05-16. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1295) somente com totais para PE - 2020-05-17. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1283) somente com totais para PE - 2020-05-17. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1330) somente com totais para PE - 2020-05-18. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1325) somente com totais para PE - 2020-05-18. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1406) somente com totais para PE - 2020-05-19. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1395) somente com totais para PE - 2020-05-19. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2032) somente com totais para PE - 2020-05-29. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2182) somente com totais para PE - 2020-05-31. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1451) somente com totais para PE - 2020-05-20. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1707) somente com totais para PE - 2020-05-24. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2181) somente com totais para PE - 2020-05-31. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1472) somente com totais para PE - 2020-05-20. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1607) somente com totais para PE - 2020-05-22. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1512) somente com totais para PE - 2020-05-21. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1712) somente com totais para PE - 2020-05-24. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1563) somente com totais para PE - 2020-05-21. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1602) somente com totais para PE - 2020-05-22. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2615) somente com totais para SE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1642) somente com totais para PE - 2020-05-23. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1645) somente com totais para PE - 2020-05-23. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1781) somente com totais para PE - 2020-05-25. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1798) somente com totais para PE - 2020-05-25. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2116) somente com totais para PE - 2020-05-30. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2261) somente com totais para PE - 2020-06-01. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1852) somente com totais para PE - 2020-05-26. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1853) somente com totais para PE - 2020-05-26. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2035) somente com totais para PE - 2020-05-29. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1914) somente com totais para PE - 2020-05-27. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1905) somente com totais para PE - 2020-05-27. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2234) somente com totais para PE - 2020-06-01. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1970) somente com totais para PE - 2020-05-28. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (1982) somente com totais para PE - 2020-05-28. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2595) somente com totais para PE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2563) somente com totais para BA - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2564) somente com totais para CE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2619) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2614) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2096) somente com totais para PE - 2020-05-30. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2624) somente com totais para RN - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2621) somente com totais para RN - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2567) somente com totais para MS - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2569) somente com totais para PE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2570) somente com totais para PR - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2572) somente com totais para RN - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2571) somente com totais para RJ - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2622) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2565) somente com totais para DF - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2625) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2566) somente com totais para GO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2568) somente com totais para PA - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2573) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2626) somente com totais para TO - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2641) somente com totais para PE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2296) somente com totais para PE - 2020-06-02. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2584) somente com totais para AP - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2585) somente com totais para BA - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2586) somente com totais para CE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2587) somente com totais para DF - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2588) somente com totais para ES - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2589) somente com totais para GO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2590) somente com totais para MA - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2591) somente com totais para MG - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2592) somente com totais para MS - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2593) somente com totais para PA - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2594) somente com totais para PB - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2596) somente com totais para PR - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2597) somente com totais para RJ - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2297) somente com totais para PE - 2020-06-02. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2360) somente com totais para PE - 2020-06-03. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2375) somente com totais para PE - 2020-06-03. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2432) somente com totais para PE - 2020-06-04. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2579) somente com totais para MS - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2427) somente com totais para PE - 2020-06-04. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2598) somente com totais para RN - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2599) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2580) somente com totais para MA - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2600) somente com totais para RS - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2601) somente com totais para SC - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2602) somente com totais para SE - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2603) somente com totais para SP - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2604) somente com totais para TO - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2508) somente com totais para PE - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2482) somente com totais para PE - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2606) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2607) somente com totais para TO - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2581) somente com totais para AC - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2582) somente com totais para AL - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2583) somente com totais para AM - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2609) somente com totais para TO - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2608) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2559) somente com totais para PE - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2610) somente com totais para MT - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2612) somente com totais para TO - 2020-06-05. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2611) somente com totais para RO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2694) somente com totais para AM - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2692) somente com totais para AC - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2693) somente com totais para AL - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2695) somente com totais para CE - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2696) somente com totais para DF - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2700) somente com totais para PR - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2697) somente com totais para MT - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2699) somente com totais para PI - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2701) somente com totais para RO - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2703) somente com totais para SC - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2710) somente com totais para TO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2704) somente com totais para TO - 2020-06-06. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2789) somente com totais para PI - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2782) somente com totais para BA - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2780) somente com totais para AL - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2781) somente com totais para AP - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2784) somente com totais para DF - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2783) somente com totais para CE - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2785) somente com totais para MS - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2786) somente com totais para MT - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2787) somente com totais para PB - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2788) somente com totais para PE - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2790) somente com totais para PR - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2791) somente com totais para RJ - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2792) somente com totais para RO - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2793) somente com totais para RR - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2702) somente com totais para RR - 2020-06-07. Corrigindo os números para as cidades usando os dados da planilha anterior.
Planilha (2794) somente com totais para RS - 2020-06-08. Corrigindo os números para as cidades usando os dados da planilha anterior.
------
160 planilhas somente com totais.
140 tiveram os dados para múnicipios atualizados.
```

Como dá pra ver, preferi logar mesmo somente as entradas que de fato foram manipuladas e, no final, colocar um resumo das planilhas que só tiveram totais e foram checadas. Além disso, estou ignorando as planilhas que tenham os status `CHECK_FAILED` porque isso significa que elas já foram comparadas com a planilha anterior e falharam.