### PR TITLE
Atualiza validação de dados históricos

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -32,12 +32,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -I -r dev-requirements.txt
-    - name: Run black
-      run: |
-        black . --exclude "docker" -l 120 --check
-    - name: Run flake8
-      run: |
-        flake8 --config setup.cfg
     - name: Migrate and Update Data
       run: |
         python manage.py migrate --no-input
@@ -47,3 +41,9 @@ jobs:
     - name: Run Tests
       run: |
         pytest
+    - name: Run black
+      run: |
+        black . --exclude "docker" -l 120 --check
+    - name: Run flake8
+      run: |
+        flake8 --config setup.cfg

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -166,7 +166,7 @@ def validate_historical_data(spreadsheet):
     def lower_numbers(previous, data):
         if not previous:
             return False
-        return data["confirmed"] < previous.confirmed or data["deaths"] < previous.deaths
+        return data["confirmed"] < previous['confirmed'] or data["deaths"] < previous['deaths']
 
     warnings = []
     clean_results = spreadsheet.table_data
@@ -178,28 +178,31 @@ def validate_historical_data(spreadsheet):
     if len(spreadsheet.table_data) == 1 and total_data:
         has_only_total = True
 
-    city_entries = covid19_stats.most_recent_city_entries_for_state(spreadsheet.state, s_date)
-    state_entry = covid19_stats.most_recent_state_entry(spreadsheet.state, s_date)
+    city_entries, state_entry = [], {}
+    most_recent = StateSpreadsheet.objects.most_recent_deployed(spreadsheet.state, spreadsheet.date)
+    if most_recent:
+        state_entry = most_recent.get_total_data()
+        city_entries = most_recent.table_data_by_city.values()
 
     for entry in city_entries:
-        city_data = spreadsheet.get_data_from_city(entry.city_ibge_code)
-        if not has_only_total and not city_data and (entry.confirmed or entry.deaths):
-            validation_errors.new_error(f"{entry.city} possui dados históricos e não está presente na planilha.")
+        city_data = spreadsheet.get_data_from_city(entry['city_ibge_code'])
+        if not has_only_total and not city_data and (entry['confirmed'] or entry['deaths']):
+            validation_errors.new_error(f"{entry['city']} possui dados históricos e não está presente na planilha.")
             continue
         elif not city_data:  # previous entry for the city has 0 deaths and 0 confirmed
-            data = _parse_city_data(entry.city, entry.confirmed, entry.deaths, s_date, entry.state)
+            data = _parse_city_data(entry['city'], entry['confirmed'], entry['deaths'], s_date, entry['state'])
             clean_results.append(data)
             if not has_only_total:
                 warnings.append(
-                    f"{entry.city} possui dados históricos zerados/nulos, não presente na planilha e foi adicionado."
+                    f"{entry['city']} possui dados históricos zerados/nulos, não presente na planilha e foi adicionado."
                 )
         elif lower_numbers(entry, city_data):
-            warnings.append(f"Números de confirmados ou óbitos em {entry.city} é menor que o anterior.")
+            warnings.append(f"Números de confirmados ou óbitos em {entry['city']} é menor que o anterior.")
 
     if has_only_total:
         if state_entry:
             warnings.append(
-                f"Planilha importada somente com dados totais. Dados de cidades foram reutilizados da importação do dia {state_entry.date}."
+                f"Planilha importada somente com dados totais. Dados de cidades foram reutilizados da importação do dia {state_entry['date']}."
             )
         else:
             warnings.append("Planilha importada somente com dados totais.")

--- a/covid19/stats.py
+++ b/covid19/stats.py
@@ -305,30 +305,6 @@ class Covid19Stats:
     def city_data_for_state(self, state):
         return [row for row in self.city_data if row["state"] == state]
 
-    def most_recent_city_entries_for_state(self, state, date):
-        return self._get_latest_cases(state, date, "city")
-
-    def most_recent_state_entry(self, state, date):
-        return self._get_latest_cases(state, date, "state")
-
-    def _get_latest_cases(self, state, date, place_type):
-        cases = self.Caso.objects.filter(state=state, date__lte=date, place_type=place_type).iterator()
-
-        place_key_func = lambda row: (row.place_type, row.state, row.city)  # noqa
-        order_func = lambda row: row.order_for_place  # noqa
-        cases = sorted(cases, key=place_key_func)
-
-        result = []
-        for place_key, entries in groupby(cases, key=place_key_func):
-            entries = sorted(entries, key=order_func, reverse=True)
-            result.append(entries[0])
-
-        if place_type == "state" and result:
-            assert len(result) == 1
-            result = result[0]
-
-        return result
-
     def aggregate_state_data(self, select_columns, groupby_columns, state=None):
         qs = self.CasoFull.objects.filter(place_type="state")
         if state is not None:


### PR DESCRIPTION
Esse PR atualiza o processo de validação de dados históricos para confiar nos dados que estão na tabela `StateSpreadsheet` ao invés dos dados que já foram carregados para o dataset de `Caso`.