### PR TITLE
Sticky page footer

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -54,10 +54,10 @@
 
     {% block top %}{% endblock %}
 
-    <div class="container">
+    <main class="container">
       {% block content %}{% endblock %}
-    </div>
-    <div class="footer indigo darken-4">
+    </main>
+    <footer class="footer indigo darken-4">
 
       <div class="container">
         <section id="newsletter">
@@ -122,7 +122,7 @@
             | <a href="{% url 'core:collaborate' %}">Colabore</a>
         </div>
       </div>
-    </div>
+    </footer>
 
   </body>
 </html>

--- a/static/css/application.css
+++ b/static/css/application.css
@@ -15,6 +15,12 @@ body {
   min-height: 100%;
   font-family: Roboto, sans-serif;
   font-weight: 300;
+  flex-direction: column;
+  display: flex;
+}
+
+main {
+  flex: 1 0 auto;
 }
 
 .divider-new:before {


### PR DESCRIPTION
Correção de posição de footer, com adição do código css e substituição das tags, o footer fica sempre posicionado na base da página.

Resultado:
![1](https://user-images.githubusercontent.com/26860387/84429295-440d8100-abfe-11ea-970a-b122e684c25c.jpg)

Fixes #317