### PR TITLE
Fix footer layout on login page

### DIFF
--- a/static/css/application.css
+++ b/static/css/application.css
@@ -12,9 +12,11 @@ html {
 body {
   position: relative;
   margin: 0;
-  min-height: 100%;
   font-family: Roboto, sans-serif;
   font-weight: 300;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
 }
 
 .divider-new:before {
@@ -52,6 +54,7 @@ body {
 
 .container {
   padding: 10px;
+  flex: 1 0 auto;
 }
 
 .card .card-action a:not(.btn):not(.btn-large):not(.btn-small):not(.btn-large):not(.btn-floating) {


### PR DESCRIPTION
 Nas páginas em que tem pouco conteúdo o footer estava subindo junto com o conteúdo.

![84426269-546f2d00-abf9-11ea-844a-71945d65b81e](https://user-images.githubusercontent.com/24974469/84693316-ae376600-af1d-11ea-851d-4204791b9298.jpg)

Correção: 
![Captura de tela de 2020-06-15 15-30-45](https://user-images.githubusercontent.com/24974469/84693231-91029780-af1d-11ea-94f6-c003c79e3d4a.png)


Close issue #317