### PR TITLE
Exportação de dados somente com entrada para totais

### DIFF
--- a/covid19/management/commands/update_state_totals.py
+++ b/covid19/management/commands/update_state_totals.py
@@ -34,11 +34,7 @@ class Command(BaseCommand):
         parser.add_argument("--only", help="Execute comando apenas para esses estados (separados por vírgula)")
 
     def get_state_option(self, kwargs, name):
-        return [
-            state.strip().upper()
-            for state in (kwargs.get(name, "") or "").split(",")
-            if state.strip()
-        ]
+        return [state.strip().upper() for state in (kwargs.get(name, "") or "").split(",") if state.strip()]
 
     def handle(self, *args, **kwargs):
         force = self.get_state_option(kwargs, "force")

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -132,6 +132,7 @@ class StateSpreadsheet(models.Model):
         (CHECK_FAILED, "check-failed"),
         (DEPLOYED, "deployed"),
     )
+    ONLY_WITH_TOTAL_WARNING = 'Planilha importada somente com dados totais.'
 
     objects = StateSpreadsheetManager.from_queryset(StateSpreadsheetQuerySet)()
 
@@ -221,6 +222,10 @@ class StateSpreadsheet(models.Model):
     @property
     def admin_url(self):
         return reverse("admin:covid19_statespreadsheet_change", args=[self.pk])
+
+    @property
+    def only_with_total_entry(self):
+        return any([w for w in self.warnings if w.startswith(self.ONLY_WITH_TOTAL_WARNING)])
 
     def get_data_from_city(self, ibge_code):
         if ibge_code:  # ibge_code = None match for undefined data

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -70,21 +70,14 @@ class StateSpreadsheetManager(models.Manager):
         """Return all state cases, grouped by date"""
         from covid19.spreadsheet_validator import TOTAL_LINE_DISPLAY
 
-        cases, reports = {}, {}
+        cases, reports = defaultdict(dict), {}
         qs = self.get_queryset()
         spreadsheets = qs.deployable_for_state(state, avoid_peer_review_dupes=False)
+        dates_only_with_total = set()
+
         for spreadsheet in spreadsheets:
             date = spreadsheet.date
-            # TODO: test 1: quando para a data no estado só tem a planilha de total,
-            # devolve apenas o valor total
-            # TODO: test 2: quando para a data no estado tem a planilha de total e outras
-            # de município, devolve os dados completos usando as informações mais novas.
-            # TODO: test 2a: planilha total mais atualizada que deployed (total + deployed)
-            # TODO: test 2b: planilha deployed mais atualizada que total (deployed)
-            if date in cases:
-                # TODO: se a data já estiver no cases mas for só total e essa
-                # spreadsheet não for total, não pular (mas só sobrescrever dados
-                # do município)
+            if date in cases and date not in dates_only_with_total:
                 continue
 
             # Group all notes for a same URL to avoid repeated entries for date/url
@@ -95,10 +88,13 @@ class StateSpreadsheetManager(models.Manager):
 
             if spreadsheet.only_with_total_entry:
                 rows = [spreadsheet.get_total_data()]
+                dates_only_with_total.add(spreadsheet.date)
+            elif spreadsheet.date in dates_only_with_total:
+                rows = spreadsheet.table_data_by_city.values()
             else:
                 rows = spreadsheet.table_data
 
-            cases[date] = {}
+
             for row in rows:
                 city = row["city"]
                 if city is None:

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -93,8 +93,13 @@ class StateSpreadsheetManager(models.Manager):
                 report_data[url].append(spreadsheet.boletim_notes or '')
             reports[date] = report_data
 
+            if spreadsheet.only_with_total_entry:
+                rows = [spreadsheet.get_total_data()]
+            else:
+                rows = spreadsheet.table_data
+
             cases[date] = {}
-            for row in spreadsheet.data["table"]:
+            for row in rows:
                 city = row["city"]
                 if city is None:
                     city = TOTAL_LINE_DISPLAY

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -1,6 +1,6 @@
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from collections import defaultdict
 
 from django.contrib.auth import get_user_model
 from django.contrib.postgres.fields import ArrayField, JSONField
@@ -65,7 +65,6 @@ class StateSpreadsheetQuerySet(models.QuerySet):
 
 
 class StateSpreadsheetManager(models.Manager):
-
     def get_state_data(self, state):
         """Return all state cases, grouped by date"""
         from covid19.spreadsheet_validator import TOTAL_LINE_DISPLAY
@@ -83,7 +82,7 @@ class StateSpreadsheetManager(models.Manager):
             # Group all notes for a same URL to avoid repeated entries for date/url
             report_data = reports.get(date, defaultdict(list))
             for url in spreadsheet.boletim_urls:
-                report_data[url].append(spreadsheet.boletim_notes or '')
+                report_data[url].append(spreadsheet.boletim_notes or "")
             reports[date] = report_data
 
             if spreadsheet.only_with_total_entry:
@@ -133,7 +132,7 @@ class StateSpreadsheet(models.Model):
         (CHECK_FAILED, "check-failed"),
         (DEPLOYED, "deployed"),
     )
-    ONLY_WITH_TOTAL_WARNING = 'Planilha importada somente com dados totais.'
+    ONLY_WITH_TOTAL_WARNING = "Planilha importada somente com dados totais."
 
     objects = StateSpreadsheetManager.from_queryset(StateSpreadsheetQuerySet)()
 

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -88,12 +88,12 @@ class StateSpreadsheetManager(models.Manager):
 
             if spreadsheet.only_with_total_entry:
                 rows = [spreadsheet.get_total_data()]
-                dates_only_with_total.add(spreadsheet.date)
-            elif spreadsheet.date in dates_only_with_total:
+                dates_only_with_total.add(date)
+            elif date in dates_only_with_total:
                 rows = spreadsheet.table_data_by_city.values()
+                dates_only_with_total.remove(date)
             else:
                 rows = spreadsheet.table_data
-
 
             for row in rows:
                 city = row["city"]

--- a/covid19/spreadsheet.py
+++ b/covid19/spreadsheet.py
@@ -111,25 +111,3 @@ def row_with_sorted_columns(row):
         new[deaths] = row[deaths]
 
     return new
-
-
-def create_merged_state_spreadsheet(state):
-    state_data = merge_state_data(state)
-    reports = rows.import_from_dicts(state_data["reports"])
-    cases = rows.import_from_dicts(state_data["cases"])
-
-    data = io.BytesIO()
-    rows.export_to_xlsx(reports, data, sheet_name=google_data.BOLETIM_SPREADSHEET)
-    data.seek(0)
-    rows.export_to_xlsx(cases, data, sheet_name=google_data.CASOS_SPREADSHEET)
-    data.seek(0)
-    return data
-
-
-if __name__ == "__main__":
-    # XXX: Run this on `manage.py shell`:
-    from covid19.spreadsheet import create_merged_state_spreadsheet  # noqa
-
-    data = create_merged_state_spreadsheet("AC")
-    with open("acre.xlsx", mode="wb") as fobj:
-        fobj.write(data.read())

--- a/covid19/spreadsheet.py
+++ b/covid19/spreadsheet.py
@@ -1,8 +1,3 @@
-import io
-from collections import defaultdict
-
-import rows
-
 from brazil_data.cities import get_city_info
 from covid19 import google_data
 from covid19.exceptions import SpreadsheetValidationErrors

--- a/covid19/spreadsheet.py
+++ b/covid19/spreadsheet.py
@@ -16,7 +16,16 @@ def get_state_data_from_db(state):
     spreadsheets = StateSpreadsheet.objects.deployable_for_state(state, avoid_peer_review_dupes=False)
     for spreadsheet in spreadsheets:
         date = spreadsheet.date
+        # TODO: test 1: quando para a data no estado só tem a planilha de total,
+        # devolve apenas o valor total
+        # TODO: test 2: quando para a data no estado tem a planilha de total e outras
+        # de município, devolve os dados completos usando as informações mais novas.
+        # TODO: test 2a: planilha total mais atualizada que deployed (total + deployed)
+        # TODO: test 2b: planilha deployed mais atualizada que total (deployed)
         if date in cases:
+            # TODO: se a data já estiver no cases mas for só total e essa
+            # spreadsheet não for total, não pular (mas só sobrescrever dados
+            # do município)
             continue
 
         # Group all notes for a same URL to avoid repeated entries for date/url

--- a/covid19/spreadsheet_validator.py
+++ b/covid19/spreadsheet_validator.py
@@ -202,10 +202,10 @@ def validate_historical_data(spreadsheet):
     if has_only_total:
         if state_entry:
             warnings.append(
-                f"Planilha importada somente com dados totais. Dados de cidades foram reutilizados da importação do dia {state_entry['date']}."
+                f"{StateSpreadsheet.ONLY_WITH_TOTAL_WARNING} Dados de cidades foram reutilizados da importação do dia {state_entry['date']}."
             )
         else:
-            warnings.append("Planilha importada somente com dados totais.")
+            warnings.append(StateSpreadsheet.ONLY_WITH_TOTAL_WARNING)
 
     if lower_numbers(state_entry, total_data):
         warnings.append("Números de confirmados ou óbitos totais é menor que o total anterior.")

--- a/covid19/tests/test_models.py
+++ b/covid19/tests/test_models.py
@@ -372,21 +372,20 @@ class StateSpreadsheetTests(TestCase):
 
 
 class StateSpreadsheetManagerTests(TestCase):
-
     def setUp(self):
-        self.state = 'PR'
+        self.state = "PR"
         self.date = date.today()
 
     def assertDataEntry(self, cases, date, label, confirmed, deaths):
-        assert date in cases, f'No cases for date {date}'
-        assert label in cases[date], f'No entry for {label} on date {date}'
-        assert {'confirmed': confirmed, 'deaths': deaths} == cases[date][label]
+        assert date in cases, f"No cases for date {date}"
+        assert label in cases[date], f"No entry for {label} on date {date}"
+        assert {"confirmed": confirmed, "deaths": deaths} == cases[date][label]
 
     def test_get_report_data_from_state(self):
         sp = baker.make(
             StateSpreadsheet,
-            boletim_urls=['https://brasil.io/', 'https://saude.gov.br/'],
-            boletim_notes='foo',
+            boletim_urls=["https://brasil.io/", "https://saude.gov.br/"],
+            boletim_notes="foo",
             status=StateSpreadsheet.DEPLOYED,
             state=self.state,
             date=self.date,
@@ -423,24 +422,19 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         sp.save()
 
-        report_data = StateSpreadsheet.objects.get_state_data('PR')
-        reports, cases = report_data['reports'], report_data['cases']
+        report_data = StateSpreadsheet.objects.get_state_data("PR")
+        reports, cases = report_data["reports"], report_data["cases"]
 
         assert 2 == len(reports)
-        assert {'date': self.date, 'url': 'https://brasil.io/', 'notes': 'foo'} in reports
-        assert {'date': self.date, 'url': 'https://saude.gov.br/', 'notes': 'foo'} in reports
+        assert {"date": self.date, "url": "https://brasil.io/", "notes": "foo"} in reports
+        assert {"date": self.date, "url": "https://saude.gov.br/", "notes": "foo"} in reports
         assert 1 == len(cases)
-        self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 12, 7)
-        self.assertDataEntry(cases, self.date, 'Importados/Indefinidos', 2, 2)
-        self.assertDataEntry(cases, self.date, 'Curitiba', 10, 5)
+        self.assertDataEntry(cases, self.date, "TOTAL NO ESTADO", 12, 7)
+        self.assertDataEntry(cases, self.date, "Importados/Indefinidos", 2, 2)
+        self.assertDataEntry(cases, self.date, "Curitiba", 10, 5)
 
     def test_report_data_should_exclude_city_entries_if_spreadsheet_only_with_total(self):
-        sp = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
-        )
+        sp = baker.make(StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,)
         sp_date = self.date.isoformat()
         sp.warnings = [StateSpreadsheet.ONLY_WITH_TOTAL_WARNING]
         sp.table_data = [
@@ -465,18 +459,15 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         sp.save()
 
-        cases = StateSpreadsheet.objects.get_state_data('PR')['cases']
+        cases = StateSpreadsheet.objects.get_state_data("PR")["cases"]
 
-        self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 12, 7)
+        self.assertDataEntry(cases, self.date, "TOTAL NO ESTADO", 12, 7)
         assert 1 == len(cases[self.date])
 
     def test_report_data_should_list_previous_deployed_city_entries_if_spreadsheet_only_with_total(self):
         sp_date = self.date.isoformat()
         previous_deployed = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
+            StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,
         )
         previous_deployed.table_data = [
             {
@@ -509,12 +500,7 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         previous_deployed.save()
 
-        total_sp = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
-        )
+        total_sp = baker.make(StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,)
         total_sp_date = self.date.isoformat()
         total_sp.warnings = [StateSpreadsheet.ONLY_WITH_TOTAL_WARNING]
         total_sp.table_data = [
@@ -539,19 +525,16 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         total_sp.save()
 
-        cases = StateSpreadsheet.objects.get_state_data('PR')['cases']
+        cases = StateSpreadsheet.objects.get_state_data("PR")["cases"]
 
-        self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 50, 20)
-        self.assertDataEntry(cases, self.date, 'Importados/Indefinidos', 2, 2)
-        self.assertDataEntry(cases, self.date, 'Curitiba', 10, 5)
+        self.assertDataEntry(cases, self.date, "TOTAL NO ESTADO", 50, 20)
+        self.assertDataEntry(cases, self.date, "Importados/Indefinidos", 2, 2)
+        self.assertDataEntry(cases, self.date, "Curitiba", 10, 5)
 
     def test_report_data_should_ignore_previous_if_city_data_was_already_exported(self):
         sp_date = self.date.isoformat()
         previous_total = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
+            StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,
         )
         previous_total.warnings = [StateSpreadsheet.ONLY_WITH_TOTAL_WARNING]
         previous_total.table_data = [
@@ -567,12 +550,7 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         previous_total.save()
 
-        sp = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
-        )
+        sp = baker.make(StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,)
         sp_date = self.date.isoformat()
         sp.table_data = [
             {
@@ -605,19 +583,16 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         sp.save()
 
-        cases = StateSpreadsheet.objects.get_state_data('PR')['cases']
+        cases = StateSpreadsheet.objects.get_state_data("PR")["cases"]
 
-        self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 20, 10)
-        self.assertDataEntry(cases, self.date, 'Importados/Indefinidos', 12, 9)
-        self.assertDataEntry(cases, self.date, 'Curitiba', 8, 1)
+        self.assertDataEntry(cases, self.date, "TOTAL NO ESTADO", 20, 10)
+        self.assertDataEntry(cases, self.date, "Importados/Indefinidos", 12, 9)
+        self.assertDataEntry(cases, self.date, "Curitiba", 8, 1)
 
     def test_ensure_previous_city_data_is_always_using_the_most_recent_one(self):
         sp_date = self.date.isoformat()
         older_previous_deployed = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
+            StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,
         )
         older_previous_deployed.table_data = [
             {
@@ -651,10 +626,7 @@ class StateSpreadsheetManagerTests(TestCase):
         older_previous_deployed.save()
 
         previous_deployed = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
+            StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,
         )
         previous_deployed.table_data = [
             {
@@ -687,12 +659,7 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         previous_deployed.save()
 
-        total_sp = baker.make(
-            StateSpreadsheet,
-            status=StateSpreadsheet.DEPLOYED,
-            state=self.state,
-            date=self.date,
-        )
+        total_sp = baker.make(StateSpreadsheet, status=StateSpreadsheet.DEPLOYED, state=self.state, date=self.date,)
         total_sp_date = self.date.isoformat()
         total_sp.warnings = [StateSpreadsheet.ONLY_WITH_TOTAL_WARNING]
         total_sp.table_data = [
@@ -708,8 +675,8 @@ class StateSpreadsheetManagerTests(TestCase):
         ]
         total_sp.save()
 
-        cases = StateSpreadsheet.objects.get_state_data('PR')['cases']
+        cases = StateSpreadsheet.objects.get_state_data("PR")["cases"]
 
-        self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 50, 20)
-        self.assertDataEntry(cases, self.date, 'Importados/Indefinidos', 2, 2)
-        self.assertDataEntry(cases, self.date, 'Curitiba', 10, 5)
+        self.assertDataEntry(cases, self.date, "TOTAL NO ESTADO", 50, 20)
+        self.assertDataEntry(cases, self.date, "Importados/Indefinidos", 2, 2)
+        self.assertDataEntry(cases, self.date, "Curitiba", 10, 5)

--- a/covid19/tests/test_models.py
+++ b/covid19/tests/test_models.py
@@ -610,3 +610,106 @@ class StateSpreadsheetManagerTests(TestCase):
         self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 20, 10)
         self.assertDataEntry(cases, self.date, 'Importados/Indefinidos', 12, 9)
         self.assertDataEntry(cases, self.date, 'Curitiba', 8, 1)
+
+    def test_ensure_previous_city_data_is_always_using_the_most_recent_one(self):
+        sp_date = self.date.isoformat()
+        older_previous_deployed = baker.make(
+            StateSpreadsheet,
+            status=StateSpreadsheet.DEPLOYED,
+            state=self.state,
+            date=self.date,
+        )
+        older_previous_deployed.table_data = [
+            {
+                "city": None,
+                "city_ibge_code": 41,
+                "confirmed": 12,
+                "date": sp_date,
+                "deaths": 7,
+                "place_type": "state",
+                "state": self.state,
+            },
+            {
+                "city": "Importados/Indefinidos",
+                "city_ibge_code": None,
+                "confirmed": 5,
+                "date": sp_date,
+                "deaths": 5,
+                "place_type": "city",
+                "state": self.state,
+            },
+            {
+                "city": "Curitiba",
+                "city_ibge_code": 4321,
+                "confirmed": 7,
+                "date": sp_date,
+                "deaths": 2,
+                "place_type": "city",
+                "state": self.state,
+            },
+        ]
+        older_previous_deployed.save()
+
+        previous_deployed = baker.make(
+            StateSpreadsheet,
+            status=StateSpreadsheet.DEPLOYED,
+            state=self.state,
+            date=self.date,
+        )
+        previous_deployed.table_data = [
+            {
+                "city": None,
+                "city_ibge_code": 41,
+                "confirmed": 12,
+                "date": sp_date,
+                "deaths": 7,
+                "place_type": "state",
+                "state": self.state,
+            },
+            {
+                "city": "Importados/Indefinidos",
+                "city_ibge_code": None,
+                "confirmed": 2,
+                "date": sp_date,
+                "deaths": 2,
+                "place_type": "city",
+                "state": self.state,
+            },
+            {
+                "city": "Curitiba",
+                "city_ibge_code": 4321,
+                "confirmed": 10,
+                "date": sp_date,
+                "deaths": 5,
+                "place_type": "city",
+                "state": self.state,
+            },
+        ]
+        previous_deployed.save()
+
+        total_sp = baker.make(
+            StateSpreadsheet,
+            status=StateSpreadsheet.DEPLOYED,
+            state=self.state,
+            date=self.date,
+        )
+        total_sp_date = self.date.isoformat()
+        total_sp.warnings = [StateSpreadsheet.ONLY_WITH_TOTAL_WARNING]
+        total_sp.table_data = [
+            {
+                "city": None,
+                "city_ibge_code": 41,
+                "confirmed": 50,
+                "date": total_sp_date,
+                "deaths": 20,
+                "place_type": "state",
+                "state": self.state,
+            },
+        ]
+        total_sp.save()
+
+        cases = StateSpreadsheet.objects.get_state_data('PR')['cases']
+
+        self.assertDataEntry(cases, self.date, 'TOTAL NO ESTADO', 50, 20)
+        self.assertDataEntry(cases, self.date, 'Importados/Indefinidos', 2, 2)
+        self.assertDataEntry(cases, self.date, 'Curitiba', 10, 5)

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -581,8 +581,10 @@ class TestValidateSpreadsheetWithHistoricalData(Covid19DatasetTestCase):
             "Números de confirmados ou óbitos totais é menor que o total anterior.",
         ]
         warnings = validate_historical_data(self.spreadsheet)
+        self.spreadsheet.warnings = warnings
 
         assert expected == warnings
+        assert self.spreadsheet.only_with_total_entry is False
 
     def test_if_city_is_not_present_and_previous_report_has_0_for_both_counters_add_the_entry(self):
         city_data = self.cities_data.pop(0)
@@ -616,6 +618,7 @@ class TestValidateSpreadsheetWithHistoricalData(Covid19DatasetTestCase):
         self.spreadsheet.table_data = [self.total_data]  # only total
 
         warnings = validate_historical_data(self.spreadsheet)
+        self.spreadsheet.warnings = warnings
 
         assert self.total_data in self.spreadsheet.table_data
         assert self.undefined_data in self.spreadsheet.table_data
@@ -630,12 +633,15 @@ class TestValidateSpreadsheetWithHistoricalData(Covid19DatasetTestCase):
         assert "Números de confirmados ou óbitos totais é menor que o total anterior." in warnings
         assert self.spreadsheet.get_total_data()["deaths"] == 2
         assert self.spreadsheet.get_total_data()["confirmed"] == 5
+        assert self.spreadsheet.only_with_total_entry is True
 
     def test_accept_first_spreadsheet_only_with_total_tada(self):
         self.spreadsheet.table_data = [self.total_data]  # only total
 
         warnings = validate_historical_data(self.spreadsheet)
+        self.spreadsheet.warnings = warnings
 
         assert 1 == len(self.spreadsheet.table_data)
         assert self.total_data in self.spreadsheet.table_data
         assert ["Planilha importada somente com dados totais."] == warnings
+        assert self.spreadsheet.only_with_total_entry is True

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -1,4 +1,3 @@
-import io
 import json
 from unittest.mock import patch
 

--- a/covid19/views.py
+++ b/covid19/views.py
@@ -1,7 +1,7 @@
 import datetime
 import random
 
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import render
 
 from brazil_data.cities import get_state_info
@@ -261,12 +261,7 @@ def import_spreadsheet_proxy(request, state):
         data["reports"] = [
             # Here we export the `report` again, including only the fields we
             # want (the old JSON can come with other columns).
-            {
-                "date": report["date"],
-                "notes": report["notes"],
-                "state": state_info.state,
-                "url": report["url"],
-            }
+            {"date": report["date"], "notes": report["notes"], "state": state_info.state, "url": report["url"],}
             for report in data["reports"]
             if any(report.values())
         ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.2'
 services:
 
     db:
-        image: postgres:11
+        image: postgres:10.3
         shm_size: 256m
         container_name: brasilio_postgres
         env_file: .env

--- a/scripts/migrate_old_data.py
+++ b/scripts/migrate_old_data.py
@@ -15,7 +15,7 @@ for state in STATES:
             data[state] = get_state_data_from_google_spreadsheets(state, timeout=10)
         except KeyboardInterrupt:
             break
-        except:
+        except Exception:
             print("  error, trying again")
             continue
         else:


### PR DESCRIPTION
Esse PR introduz as seguintes mudanças e validações:

1. Refatora a lógica de consolidação de dados para o domínio ao invés de delegá-la a uma função;
2. No caso de um dia ter somente uma planilha somente de totais deployed: exportamos somente a entrada de totais;
3. No caso de um dia ter a planilha deployed mais recente somente com totais, usamos os dados de cidade da planilha deployed mais recente anterior a que somente tem totais;
4. No caso de a planilha mais recente ser uma planilha completa, usamos ela e ignoramos todo o resto;