### PR TITLE
Permite limitar número de requisições na API

### DIFF
--- a/api/handlers.py
+++ b/api/handlers.py
@@ -1,0 +1,22 @@
+from rest_framework.views import exception_handler
+from rest_framework.exceptions import Throttled
+
+
+throtthling_msg = """
+Você atingiu o limite de requisições e, por isso, essa requisição foi bloqueada. Caso você precise acessar várias páginas de um dataset, por favor, baixe o dataset completo em vez de percorrer várias páginas na API (o link para baixar o arquivo completo encontra-se na página do dataset, em https://brasil.io/datasets/).
+Utilizar a API desnecessariamente e de maneira não otimizada onera muito nossos servidores e atrapalha a experiência de outros usuários. Se o abuso continuar, precisaremos restringir ainda mais a API e não gostaríamos de fazer isso.
+Lembre-se: o Brasil.IO é um projeto colaborativo, desenvolvido por voluntários e mantido por financiamento coletivo, você pode doar para o projeto em: https://apoia.se/brasilio
+""".strip()
+
+
+def api_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+
+    if isinstance(exc, Throttled):
+        custom_response_data = {
+            'message': throtthling_msg,
+            'available_in': f'{exc.wait} seconds'
+        }
+        response.data = custom_response_data
+
+    return response

--- a/api/handlers.py
+++ b/api/handlers.py
@@ -1,6 +1,5 @@
-from rest_framework.views import exception_handler
 from rest_framework.exceptions import Throttled
-
+from rest_framework.views import exception_handler
 
 throtthling_msg = """
 Você atingiu o limite de requisições e, por isso, essa requisição foi bloqueada. Caso você precise acessar várias páginas de um dataset, por favor, baixe o dataset completo em vez de percorrer várias páginas na API (o link para baixar o arquivo completo encontra-se na página do dataset, em https://brasil.io/datasets/).
@@ -13,10 +12,7 @@ def api_exception_handler(exc, context):
     response = exception_handler(exc, context)
 
     if isinstance(exc, Throttled):
-        custom_response_data = {
-            'message': throtthling_msg,
-            'available_in': f'{exc.wait} seconds'
-        }
+        custom_response_data = {"message": throtthling_msg, "available_in": f"{exc.wait} seconds"}
         response.data = custom_response_data
 
     return response

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -149,6 +149,14 @@ DATA_URL = env("DATA_URL")
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "rest_framework.throttling.UserRateThrottle"
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": env("THROTTLING_RATE"),
+        "user": env("THROTTLING_RATE"),
+    }
 }
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -149,22 +149,21 @@ DATA_URL = env("DATA_URL")
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
-    'EXCEPTION_HANDLER': 'api.handlers.api_exception_handler',
+    "EXCEPTION_HANDLER": "api.handlers.api_exception_handler",
 }
 
 THROTTLING_RATE = env("THROTTLING_RATE")
 
 if THROTTLING_RATE:
-    REST_FRAMEWORK.update({
-        "DEFAULT_THROTTLE_CLASSES": [
-            "rest_framework.throttling.AnonRateThrottle",
-            "rest_framework.throttling.UserRateThrottle"
-        ],
-        "DEFAULT_THROTTLE_RATES": {
-            "anon": THROTTLING_RATE,
-            "user": THROTTLING_RATE,
+    REST_FRAMEWORK.update(
+        {
+            "DEFAULT_THROTTLE_CLASSES": [
+                "rest_framework.throttling.AnonRateThrottle",
+                "rest_framework.throttling.UserRateThrottle",
+            ],
+            "DEFAULT_THROTTLE_RATES": {"anon": THROTTLING_RATE, "user": THROTTLING_RATE,},
         }
-    })
+    )
 
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -150,15 +150,21 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
     'EXCEPTION_HANDLER': 'api.handlers.api_exception_handler',
-    "DEFAULT_THROTTLE_CLASSES": [
-        "rest_framework.throttling.AnonRateThrottle",
-        "rest_framework.throttling.UserRateThrottle"
-    ],
-    "DEFAULT_THROTTLE_RATES": {
-        "anon": env("THROTTLING_RATE"),
-        "user": env("THROTTLING_RATE"),
-    }
 }
+
+THROTTLING_RATE = env("THROTTLING_RATE")
+
+if THROTTLING_RATE:
+    REST_FRAMEWORK.update({
+        "DEFAULT_THROTTLE_CLASSES": [
+            "rest_framework.throttling.AnonRateThrottle",
+            "rest_framework.throttling.UserRateThrottle"
+        ],
+        "DEFAULT_THROTTLE_RATES": {
+            "anon": THROTTLING_RATE,
+            "user": THROTTLING_RATE,
+        }
+    })
 
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -149,6 +149,7 @@ DATA_URL = env("DATA_URL")
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
+    'EXCEPTION_HANDLER': 'api.handlers.api_exception_handler',
     "DEFAULT_THROTTLE_CLASSES": [
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle"

--- a/env.example
+++ b/env.example
@@ -32,6 +32,7 @@ CACHE_KEY_PREFIX=datacache
 WORKERS=4
 DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage"
 STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage"
+THROTTLING_RATE=""
 
 # If using AWS storage, you'll have to populate these values
 AWS_ACCESS_KEY_ID=""


### PR DESCRIPTION
Esse PR é apenas um trabalho inicial para abrir os caminhos da issue #316 

Ainda podemos otimizar o throttling, principalmente utilizando o [`ScopedRateThrottle`](https://www.django-rest-framework.org/api-guide/throttling/#scopedratethrottle)