### PR TITLE
Altera versão do PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.2'
 services:
 
     db:
-        image: postgres:10.3
+        image: postgres:11.3
         shm_size: 256m
         container_name: brasilio_postgres
         env_file: .env


### PR DESCRIPTION
11.3 é a versão que estamos rodando no servidor - mas esse PR vai quebrar os ambientes locais de quem estiver rodando o projeto, o ideal seria adicionar um script de migração ou link na documentação (porém não consigo fazer isso agora - se alguém puder ajudar).