### PR TITLE
 Removes naomi from debug mode

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -58,7 +58,6 @@ MIDDLEWARE = [
 ]
 if DEBUG:
     MIDDLEWARE.append("utils.sqlprint.SqlPrintingMiddleware")
-    INSTALLED_APPS += ("naomi",)
 
 ROOT_URLCONF = "brasilio.urls"
 APPEND_SLASH = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ django-extensions
 django-localflavor==3.0.1
 django-markdownx
 django-minio-storage==0.3.7
-django-naomi
 django-recaptcha
 django-redis
 django-rq==2.3.2


### PR DESCRIPTION
The commit b935e08 replaced naomi with mailhog and it seems the naomi
app was kept in INSTALLED_APPS declaration when DEBUG == True. Since in
the referred commit the naomi dependency was removed from requirements
file, the project is currently failing to run in debug mode in a fresh
install.

This change removes the naomi app from INSTALLED_APPS when DEBUG ==
True and removes the django-naomi dependency.