### PR TITLE
Conserta a nav principal, que está flutuando à esquerda.

### DIFF
--- a/covid19/static/css/covid19-map.css
+++ b/covid19/static/css/covid19-map.css
@@ -1,10 +1,10 @@
-nav ul li {
+nav.nav-state-selector ul li {
   list-style-type: none; 
   display: inline-block; 
   float: none!important;
 }
 
-nav ul {
+nav.nav-state-selector ul {
   white-space: nowrap;
   overflow-x: auto; 
   overflow-y: hidden; 

--- a/covid19/templates/dashboard.html
+++ b/covid19/templates/dashboard.html
@@ -62,7 +62,7 @@
 </div>
 
 <div id="dashboard-state-selector" class="row" style="clear: both">
-  <nav>
+  <nav class="nav-state-selector">
   <div class="nav-wrapper indigo">
     <ul>
       <li{% if not state %} class="active"{% endif %}>


### PR DESCRIPTION
Uma classe foi adiciona à `nav` seletora de estado a fim de distingui-la da `nav` principal, localizada no topo da página, causada pela PR #321.  