### PR TITLE
Corrige a issue 107 do Sentry

### DIFF
--- a/core/views_special.py
+++ b/core/views_special.py
@@ -2,6 +2,7 @@ from unicodedata import normalize
 
 from cryptography.fernet import Fernet, InvalidToken
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -65,7 +66,7 @@ def document_detail(request, document):
         doc_prefix = document[:8]
         try:
             obj = get_company_by_document(document)
-        except Documents.DoesNotExist:
+        except ObjectDoesNotExist:
             raise Http404
         # From here only HQs or companies without HQs
         if document != obj.document:


### PR DESCRIPTION
O bug estava sendo causado porque o sistema parou de retornar 404 para CNPJs inexistentes.

Esse PR usa execção base de DoesNotExist porque o objeto dynamic model Document da view difere do instanciado dentro do get_company_by_document

A view recupera o model utilizando a função core.models.get_table_model enquanto a implementação da função get_company_by_document recupera o model via Table.get_model().
A função auxiliar utiliza uma estratégia de cache via lru_cache e isso pode gerar algum tipo de diferença entre as referências ao model Document.
Dessa forma, o except Document.DoesNotExist não estava sendo executa e, para resolver isso, o substituí pela classe base da exceção Model.DoesNotExist do Django

Referência aqui: https://docs.djangoproject.com/en/3.0/ref/exceptions/#objectdoesnotexist