### PR TITLE
Cria página no admin para colaboradoras admins do Covid19

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -241,6 +241,9 @@ if not DEBUG:
 # Covid19 import settings
 COVID_IMPORT_PERMISSION_PREFIX = "can_import_covid_state_"
 COVID_19_ADMIN_GROUP_NAME = "Admins Covid-19"
+COVID_19_STATE_TOTALS_URL = (
+    "https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/export?format=csv"
+)
 
 # RockecChat config
 ROCKETCHAT_BASE_URL = env("ROCKETCHAT_BASE_URL")

--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -1,6 +1,7 @@
 import csv
 import io
 
+from django.conf import settings
 from django.contrib import admin
 from django.db import transaction
 from django.http import Http404, HttpResponse
@@ -188,6 +189,7 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
         if not user_has_covid_19_admin_permissions(request.user):
             raise Http404
         context = self.admin_site.each_context(request)
+        context["state_totals_url"] = settings.COVID_19_STATE_TOTALS_URL.split('export')[0]
 
         if request.GET.get("action", None) == "update_state_totals":
             stdout = io.StringIO()

--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -1,4 +1,5 @@
 import csv
+import io
 
 from django.contrib import admin
 from django.db import transaction
@@ -10,6 +11,7 @@ from django.utils.html import format_html
 
 from brazil_data.cities import brazilian_cities_per_state
 from brazil_data.states import STATES
+from covid19.commands import UpdateStateTotalsCommand
 from covid19.forms import StateSpreadsheetForm, state_choices_for_user
 from covid19.models import DailyBulletin, StateSpreadsheet
 from covid19.permissions import user_has_covid_19_admin_permissions, user_has_state_permission
@@ -63,11 +65,7 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
                 self.admin_site.admin_view(self.sample_spreadsheet_view),
                 name="sample_covid_spreadsheet",
             ),
-            path(
-                "gerenciar",
-                self.admin_site.admin_view(self.covid19_management_view),
-                name="covid19_management",
-            ),
+            path("gerenciar", self.admin_site.admin_view(self.covid19_management_view), name="covid19_management",),
         ]
         return custom_urls + urls
 
@@ -189,7 +187,13 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
         if not user_has_covid_19_admin_permissions(request.user):
             raise Http404
         context = self.admin_site.each_context(request)
-        return render(request, 'admin/covid19_admins_page.html', context=context)
+
+        if request.GET.get("action", None) == "update_state_totals":
+            stdout = io.StringIO()
+            UpdateStateTotalsCommand.execute(request.user, stdout=stdout)
+            stdout.seek(0)
+            context["action_output"] = stdout.read()
+        return render(request, "admin/covid19_admins_page.html", context=context)
 
 
 admin.site.register(StateSpreadsheet, StateSpreadsheetModelAdmin)

--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -56,6 +56,7 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
     form = StateSpreadsheetForm
     ordering = ["-created_at"]
     add_form_template = "admin/covid19_add_form.html"
+    change_list_template = "admin/covid19_list.html"
 
     def get_urls(self):
         urls = super().get_urls()
@@ -194,6 +195,11 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
             stdout.seek(0)
             context["action_output"] = stdout.read()
         return render(request, "admin/covid19_admins_page.html", context=context)
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["covid19_admin"] = user_has_covid_19_admin_permissions(request.user)
+        return super().changelist_view(request, extra_context)
 
 
 admin.site.register(StateSpreadsheet, StateSpreadsheetModelAdmin)

--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -3,6 +3,7 @@ import csv
 from django.contrib import admin
 from django.db import transaction
 from django.http import Http404, HttpResponse
+from django.shortcuts import render
 from django.templatetags.static import static
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -61,6 +62,11 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
                 "planilha-model/<str:state>/",
                 self.admin_site.admin_view(self.sample_spreadsheet_view),
                 name="sample_covid_spreadsheet",
+            ),
+            path(
+                "gerenciar",
+                self.admin_site.admin_view(self.covid19_management_view),
+                name="covid19_management",
             ),
         ]
         return custom_urls + urls
@@ -178,6 +184,12 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
         writer.writerows(csv_rows)
 
         return response
+
+    def covid19_management_view(self, request):
+        if not user_has_covid_19_admin_permissions(request.user):
+            raise Http404
+        context = self.admin_site.each_context(request)
+        return render(request, 'admin/covid19_admins_page.html', context=context)
 
 
 admin.site.register(StateSpreadsheet, StateSpreadsheetModelAdmin)

--- a/covid19/admin.py
+++ b/covid19/admin.py
@@ -189,7 +189,7 @@ class StateSpreadsheetModelAdmin(admin.ModelAdmin):
         if not user_has_covid_19_admin_permissions(request.user):
             raise Http404
         context = self.admin_site.each_context(request)
-        context["state_totals_url"] = settings.COVID_19_STATE_TOTALS_URL.split('export')[0]
+        context["state_totals_url"] = settings.COVID_19_STATE_TOTALS_URL.split("export")[0]
 
         if request.GET.get("action", None) == "update_state_totals":
             stdout = io.StringIO()

--- a/covid19/commands.py
+++ b/covid19/commands.py
@@ -2,6 +2,7 @@ import csv
 import io
 import os
 import socket
+import sys
 
 import requests
 import requests.packages.urllib3.util.connection as urllib3_cn
@@ -19,13 +20,14 @@ NOTES = "Dados totais coletados da Secretaria Estadual de Saúde"
 
 
 class UpdateStateTotalsCommand:
-    def __init__(self, user, force, only):
+    def __init__(self, user, force, only, stdout):
         self.user = user
         self.force = force
         self.only = only
+        self.stdout = stdout
 
-    def debug(self, message):
-        print(message)
+    def debug(self, message, end="\n"):
+        self.stdout.write(message + end)
 
     def get_spreadsheet_rows(self):
         self.debug(f"Downloading spreadsheet from {STATE_TOTALS_URL}")
@@ -118,7 +120,7 @@ class UpdateStateTotalsCommand:
         self.debug(message)
 
     @classmethod
-    def execute(cls, user, force=None, only=None):
-        self = cls(user, force or [], only or [])
+    def execute(cls, user, force=None, only=None, stdout=None):
+        self = cls(user, force or [], only or [], stdout or sys.stdout)
         for row in self.get_spreadsheet_rows():
             self.process_state_row(row)

--- a/covid19/commands.py
+++ b/covid19/commands.py
@@ -16,8 +16,6 @@ STATE_TOTALS_URL = (
     "https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/export?format=csv"
 )
 NOTES = "Dados totais coletados da Secretaria Estadual de Saúde"
-STATUS = {value: key for key, value in StateSpreadsheet.STATUS_CHOICES}
-STATUS_DEPLOYED = STATUS["deployed"]
 
 
 class UpdateStateTotalsCommand:

--- a/covid19/commands.py
+++ b/covid19/commands.py
@@ -1,0 +1,117 @@
+import csv
+import io
+import os
+import socket
+
+import requests
+import requests.packages.urllib3.util.connection as urllib3_cn
+import rows
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from covid19.forms import StateSpreadsheetForm
+from covid19.models import StateSpreadsheet
+
+urllib3_cn.allowed_gai_family = lambda: socket.AF_INET  # Force IPv4
+STATE_TOTALS_URL = (
+    "https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/export?format=csv"
+)
+NOTES = "Dados totais coletados da Secretaria Estadual de Saúde"
+STATUS = {value: key for key, value in StateSpreadsheet.STATUS_CHOICES}
+STATUS_DEPLOYED = STATUS["deployed"]
+
+
+class UpdateStateTotalsCommand:
+    def __init__(self, user, force, only):
+        self.user = user
+        self.force = force
+        self.only = only
+
+    def debug(self, message):
+        print(message)
+
+    def get_spreadsheet_rows(self):
+        self.debug(f"Downloading spreadsheet from {STATE_TOTALS_URL}")
+        # Must NOT cache this request since the spreadsheet can change a lot
+        # during the bulletin process.
+        response = requests.get(STATE_TOTALS_URL)
+
+        self.debug("Importing spreadsheet")
+        return rows.import_from_csv(
+            io.BytesIO(response.content),
+            encoding="utf-8",
+            force_types={
+                "confirmed": rows.fields.IntegerField,
+                "data_dados": rows.fields.DateField,
+                "deaths": rows.fields.IntegerField,
+            },
+        )
+
+    def process_state_row(self, row):
+        state = str(row.state or "").upper()
+        if self.only and state not in self.only:
+            self.debug(f"{state} - SKIPPING - It's not in --only")
+            return
+
+        date = row.data_dados
+        confirmed = row.confirmed
+        deaths = row.deaths
+
+        recent_deploy = StateSpreadsheet.objects.most_recent_deployed(state, date)
+        message = None
+        status = str(row.status or "").strip().lower()
+        if status != "ok":
+            self.debug(f"{state} - SKIPPING - status = {status}")
+            return
+
+        elif recent_deploy:
+            data = recent_deploy.get_total_data()
+
+            if confirmed == data["confirmed"] and deaths == data["deaths"]:
+                self.debug(f"{state} - SKIPPING - Has the same total for deaths and confirmed")
+                return
+            elif confirmed < data["confirmed"] or deaths < data["deaths"]:
+                if self.force and state in self.force:
+                    message = f"{state} - WARNING - Would skip (already deployed for {date} and numbers of deployed are greater than ours: (ours vs deployed) {confirmed} vs {data['confirmed']}, {deaths} vs {data['deaths']}), but updating because of --force"
+                else:
+                    self.debug(
+                        f"{state} - SKIPPING - Already deployed for {date} and numbers of deployed are greater than ours: (ours vs deployed) {confirmed} vs {data['confirmed']}, {deaths} vs {data['deaths']}"
+                    )
+                    return
+            else:
+                message = f"{state} - CREATING - date: {date}"
+
+        else:
+            message = f"{state} - CREATING - date: {date}"
+
+        filename = f"/tmp/{state}-{date}.csv"
+        with open(filename, mode="w") as fobj:
+            writer = csv.writer(fobj)
+            writer.writerow(["municipio", "confirmados", "obitos"])
+            writer.writerow(["TOTAL NO ESTADO", str(confirmed), str(deaths)])
+
+        with open(filename, mode="rb") as fobj:
+            file_data = fobj.read()
+            form = StateSpreadsheetForm(
+                {"date": date, "state": state, "boletim_urls": STATE_TOTALS_URL, "boletim_notes": NOTES,},
+                {"file": SimpleUploadedFile(filename, file_data),},
+                user=self.user,
+            )
+            form_valid = form.is_valid()
+            if not form_valid:
+                self.debug(f"{state} - ERROR CREATING - Invalid form: {form.errors}")
+                return
+        os.unlink(filename)
+
+        obj = form.save()
+        StateSpreadsheet.objects.cancel_older_versions(obj)
+        obj.link_to(obj)
+        obj.import_to_final_dataset()
+        obj.refresh_from_db()
+        message += f", id = {obj.id}"
+        self.debug(message)
+
+    @classmethod
+    def execute(cls, user, force=None, only=None):
+        self = cls(user, force or [], only or [])
+        for row in self.get_spreadsheet_rows():
+            self.process_state_row(row)

--- a/covid19/commands.py
+++ b/covid19/commands.py
@@ -85,12 +85,7 @@ class UpdateStateTotalsCommand:
         if not only_total_spreadsheet:
             return
 
-        StateSpreadsheet.objects.cancel_older_versions(only_total_spreadsheet)
-        only_total_spreadsheet.link_to(only_total_spreadsheet)
-        only_total_spreadsheet.import_to_final_dataset()
-        only_total_spreadsheet.refresh_from_db()
-        message += f", id = {only_total_spreadsheet.id}"
-        self.debug(message)
+        self.deploy_spreadsheet(only_total_spreadsheet, log_prefix=message)
 
     def new_only_total_spreadsheet(self, state, date, confirmed, deaths):
         filename = f"/tmp/{state}-{date}.csv"
@@ -113,6 +108,14 @@ class UpdateStateTotalsCommand:
         os.unlink(filename)
 
         return form.save()
+
+    def deploy_spreadsheet(self, spreadsheet, log_prefix):
+        StateSpreadsheet.objects.cancel_older_versions(spreadsheet)
+        spreadsheet.link_to(spreadsheet)
+        spreadsheet.import_to_final_dataset()
+        spreadsheet.refresh_from_db()
+        message = f"{log_prefix}, id = {spreadsheet.id}"
+        self.debug(message)
 
     @classmethod
     def execute(cls, user, force=None, only=None):

--- a/covid19/commands.py
+++ b/covid19/commands.py
@@ -124,3 +124,4 @@ class UpdateStateTotalsCommand:
         self = cls(user, force or [], only or [], stdout or sys.stdout)
         for row in self.get_spreadsheet_rows():
             self.process_state_row(row)
+        self.debug("Finished!")

--- a/covid19/management/commands/update_state_totals.py
+++ b/covid19/management/commands/update_state_totals.py
@@ -1,29 +1,7 @@
-import csv
-import io
-import os
-import socket
-
-import requests
-import requests.packages.urllib3.util.connection as urllib3_cn
-import rows
 from django.contrib.auth import get_user_model
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand
 
-from covid19.forms import StateSpreadsheetForm
-from covid19.models import StateSpreadsheet
-
-urllib3_cn.allowed_gai_family = lambda: socket.AF_INET  # Force IPv4
-STATE_TOTALS_URL = (
-    "https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/export?format=csv"
-)
-NOTES = "Dados totais coletados da Secretaria Estadual de Saúde"
-STATUS = {value: key for key, value in StateSpreadsheet.STATUS_CHOICES}
-STATUS_DEPLOYED = STATUS["deployed"]
-
-
-def debug(message):
-    print(message)
+from covid19.commands import UpdateStateTotalsCommand
 
 
 class Command(BaseCommand):
@@ -40,86 +18,7 @@ class Command(BaseCommand):
         force = self.get_state_option(kwargs, "force")
         only = self.get_state_option(kwargs, "only")
 
-        username = "turicas"
-        debug(f"Getting user object for {username}")
+        username = "admin"
+        print(f"Getting user object for {username}")
         user = get_user_model().objects.get(username=username)
-
-        debug(f"Downloading spreadsheet from {STATE_TOTALS_URL}")
-        # Must NOT cache this request since the spreadsheet can change a lot
-        # during the bulletin process.
-        response = requests.get(STATE_TOTALS_URL)
-
-        debug("Importing spreadsheet")
-        spreadsheet = rows.import_from_csv(
-            io.BytesIO(response.content),
-            encoding="utf-8",
-            force_types={
-                "confirmed": rows.fields.IntegerField,
-                "data_dados": rows.fields.DateField,
-                "deaths": rows.fields.IntegerField,
-            },
-        )
-
-        for row in spreadsheet:
-            state = str(row.state or "").upper()
-            if only and state not in only:
-                debug(f"{state} - SKIPPING - It's not in --only")
-                continue
-
-            date = row.data_dados
-            confirmed = row.confirmed
-            deaths = row.deaths
-
-            recent_deploy = StateSpreadsheet.objects.most_recent_deployed(state, date)
-            message = None
-            status = str(row.status or "").strip().lower()
-            if status != "ok":
-                debug(f"{state} - SKIPPING - status = {status}")
-                continue
-
-            elif recent_deploy:
-                data = recent_deploy.get_total_data()
-
-                if confirmed == data["confirmed"] and deaths == data["deaths"]:
-                    debug(f"{state} - SKIPPING - Has the same total for deaths and confirmed")
-                    continue
-                elif confirmed < data["confirmed"] or deaths < data["deaths"]:
-                    if force and state in force:
-                        message = f"{state} - WARNING - Would skip (already deployed for {date} and numbers of deployed are greater than ours: (ours vs deployed) {confirmed} vs {data['confirmed']}, {deaths} vs {data['deaths']}), but updating because of --force"
-                    else:
-                        debug(
-                            f"{state} - SKIPPING - Already deployed for {date} and numbers of deployed are greater than ours: (ours vs deployed) {confirmed} vs {data['confirmed']}, {deaths} vs {data['deaths']}"
-                        )
-                        continue
-                else:
-                    message = f"{state} - CREATING - date: {date}"
-
-            else:
-                message = f"{state} - CREATING - date: {date}"
-
-            filename = f"/tmp/{state}-{date}.csv"
-            with open(filename, mode="w") as fobj:
-                writer = csv.writer(fobj)
-                writer.writerow(["municipio", "confirmados", "obitos"])
-                writer.writerow(["TOTAL NO ESTADO", str(confirmed), str(deaths)])
-
-            with open(filename, mode="rb") as fobj:
-                file_data = fobj.read()
-                form = StateSpreadsheetForm(
-                    {"date": date, "state": state, "boletim_urls": STATE_TOTALS_URL, "boletim_notes": NOTES,},
-                    {"file": SimpleUploadedFile(filename, file_data),},
-                    user=user,
-                )
-                form_valid = form.is_valid()
-                if not form_valid:
-                    debug(f"{state} - ERROR CREATING - Invalid form: {form.errors}")
-                    continue
-            os.unlink(filename)
-
-            obj = form.save()
-            StateSpreadsheet.objects.cancel_older_versions(obj)
-            obj.link_to(obj)
-            obj.import_to_final_dataset()
-            obj.refresh_from_db()
-            message += f", id = {obj.id}"
-            debug(message)
+        UpdateStateTotalsCommand.execute(user, force, only)

--- a/covid19/management/commands/update_state_totals.py
+++ b/covid19/management/commands/update_state_totals.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         force = self.get_state_option(kwargs, "force")
         only = self.get_state_option(kwargs, "only")
 
-        username = "admin"
+        username = "turicas"
         print(f"Getting user object for {username}")
         user = get_user_model().objects.get(username=username)
         UpdateStateTotalsCommand.execute(user, force, only)

--- a/covid19/templates/admin/covid19_admins_page.html
+++ b/covid19/templates/admin/covid19_admins_page.html
@@ -31,7 +31,14 @@ Gerenciamento Covid19
         <div class="object-tools">
           <a href="{% url 'admin:covid19_management' %}?action=update_state_totals">Atualizar Total dos Estados</a>
         </div>
-        <div class="help">Ao clicar no botão acima, o sistema irá criar novas planilhas para os estados somente com a entrada dos dados totais. Essas planilhas extrairão os dados de acordo com as entradas da planilha <a href="https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/edit#gid=0" target="_blank">brio_totais</a>. Somente as entradas que tiverem a coluna <b>status</b> com o valor <b>ok</b> serão consideradas durante a atualização.</div>
+        <div class="help">
+          Ao clicar no botão acima, o sistema irá criar novas planilhas para os estados
+          somente com a entrada dos dados totais.  Essas planilhas extrairão os dados
+          de acordo com as entradas da planilha
+          <a href="{{ state_totals_url }}" target="_blank">brio_totais</a>. Somente as
+          entradas que tiverem a coluna <b>status</b> com o valor <b>ok</b> serão
+          consideradas durante a atualização.
+        </div>
       </div>
     </div>
   </div>

--- a/covid19/templates/admin/covid19_admins_page.html
+++ b/covid19/templates/admin/covid19_admins_page.html
@@ -1,10 +1,12 @@
 {% extends "admin/base_site.html" %}
-{% load i18n  %}
+{% load static %}
 
 {% block title %}
 Gerenciamento Covid19
 {{ block.super }}
 {% endblock %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
 
 {% if not is_popup %}
 {% block breadcrumbs %}
@@ -17,5 +19,22 @@ Gerenciamento Covid19
 {% endif %}
 
 {% block content %}
-<p>Template admin</p>
+<h1>Gerenciamento de dataset Covid19</h1>
+
+<div id="content-main">
+  <p>Olá {{request.user.username}}! Nesta página você poderá desempenhar funções administrativas em cima dos dados da Covid19.</p>
+
+  <div class="module aligned">
+    <div class="form-row">
+      <div>
+        <label><b>Atualizar totais dos estados:</b></label>
+        <div class="object-tools">
+          <a href="{% url 'admin:covid19_management' %}?action=update_state_totals">Aualizar Total dos Estados</a>
+        </div>
+        <div class="help">Ao clicar no botão acima, o sistema irá criar novas planilhas para os estados somente com a entrada dos dados totais. Essas planilhas extrairão os dados de acordo com as entradas da planilha <a href="https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/edit#gid=0" target="_blank">brio_totais</a>. Somente as entradas que tiverem a coluna <b>status</b> com o valor <b>ok</b> serão consideradas durante a atualização.</div>
+      </div>
+    </div>
+  </div>
+
+</div>
 {% endblock %}

--- a/covid19/templates/admin/covid19_admins_page.html
+++ b/covid19/templates/admin/covid19_admins_page.html
@@ -29,7 +29,7 @@ Gerenciamento Covid19
       <div>
         <label><b>Atualizar totais dos estados:</b></label>
         <div class="object-tools">
-          <a href="{% url 'admin:covid19_management' %}?action=update_state_totals">Aualizar Total dos Estados</a>
+          <a href="{% url 'admin:covid19_management' %}?action=update_state_totals">Atualizar Total dos Estados</a>
         </div>
         <div class="help">Ao clicar no botão acima, o sistema irá criar novas planilhas para os estados somente com a entrada dos dados totais. Essas planilhas extrairão os dados de acordo com as entradas da planilha <a href="https://docs.google.com/spreadsheets/d/17mmfgPAcVCeHW3548BlFtuurAvF3jeffRVO1NW7rVgQ/edit#gid=0" target="_blank">brio_totais</a>. Somente as entradas que tiverem a coluna <b>status</b> com o valor <b>ok</b> serão consideradas durante a atualização.</div>
       </div>

--- a/covid19/templates/admin/covid19_admins_page.html
+++ b/covid19/templates/admin/covid19_admins_page.html
@@ -1,0 +1,21 @@
+{% extends "admin/base_site.html" %}
+{% load i18n  %}
+
+{% block title %}
+Gerenciamento Covid19
+{{ block.super }}
+{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">Início</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label='covid19' %}">Covid19</a>
+&rsaquo; Gerenciamento Covid19
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}
+<p>Template admin</p>
+{% endblock %}

--- a/covid19/templates/admin/covid19_admins_page.html
+++ b/covid19/templates/admin/covid19_admins_page.html
@@ -36,5 +36,12 @@ Gerenciamento Covid19
     </div>
   </div>
 
+{% if action_output %}
+  <div id="action_output">
+    <h2>Output</h2>
+    <div style="font-family: monospace; background:#eeeeee;">{{ action_output|linebreaksbr }}</div>
+  </div>
+{% endif %}
+
 </div>
 {% endblock %}

--- a/covid19/templates/admin/covid19_list.html
+++ b/covid19/templates/admin/covid19_list.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list.html" %}
+
+
+{% block object-tools-items %}
+  {% if covid19_admin %}
+  <li><a href="{% url 'admin:covid19_management' %}">Gerenciar Dados Covid19</a></li>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
Fixes #363 

Esse PR adiciona uma página para usuárias admins da Covid19 poderem executar ações administrativas sobre o dataset. A primeira ação introduzida é a de atualizar o total de estados.

A página fica com essa apresentação após a executar o comando:

![Screenshot from 2020-07-10 18-50-33](https://user-images.githubusercontent.com/238223/87205621-41c24380-c2de-11ea-8c19-27f461b38795.png)

E na listagem da planilha, somente pra usuárias admins, é apresentado o seguinte link ao lado do antigo link de adicionar nova planilha:

![Screenshot from 2020-07-10 18-48-14](https://user-images.githubusercontent.com/238223/87205643-4c7cd880-c2de-11ea-8fec-36558bbe0dc6.png)


