### PR TITLE
Tela doadores eixibindo do apoia.se

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -113,8 +113,8 @@
         <div class="section indigo-text text-lighten-5" style="padding-top: 0 !important;">
           <p>
             O <b>Brasil.IO</b> é mantido com muito carinho por
-            <a href="https://twitter.com/turicas" title="Twitter do Álvaro Justen">Álvaro Justen</a> e
-            <a href="{% url 'core:contributors' %}">contribuidores</a>.
+            <a href="https://twitter.com/turicas" title="Twitter do Álvaro Justen">Álvaro Justen</a>,
+            <a href="{% url 'core:contributors' %}">contribuidores</a>  e <a href="{% url 'core:donators' %}">doadores</a>.
           </p>
         </div>
         <div class="container">

--- a/core/templates/donators.html
+++ b/core/templates/donators.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Doadores - Brasil.IO{% endblock %}
+{% block head %}
+{{ block.super }}
+<!-- cdnjs -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.1/noframework.waypoints.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.1/shortcuts/infinite.js"></script>
+{% endblock %}
+
+{% block content %}
+<div class="section">
+  <h4>Doadores</h4>
+  <div class="divider"></div>
+
+  <div class="row m-t-5">
+    <p>
+      A lista abaixo é de pessoas que <i>apoiam nossa campanha</i> pela plataforma <strong>Apoia.se</strong> de
+      financiamento coletivo.
+      <a href="https://apoia.se/brasilio" title="Apoie nossa campanha">Colabore você também clicando aqui.</a>
+    </p>
+    <div class="row">
+      <div class="infinite-container col s12 center" id="container">
+        {% for donator in donators.donors %}
+        <div class="col s12 m3 m-t-15 infinite-item" style="min-height: 130px;">
+          <span class="fa-stack fa-2x text-center">
+            <img class="circle responsive-img" src="{{ donator.image }}" alt="Imagem de {{ donator.name }}">
+          </span>
+          <h6> {{ donator.name }} </h6>
+        </div>
+        {% endfor %}
+      </div>
+      <div class="loading col s12 center" style="display: none;">
+        <div class="preloader-wrapper big active">
+          <div class="spinner-layer spinner-blue-only">
+            <div class="circle-clipper left">
+              <div class="circle"></div>
+            </div>
+            <div class="gap-patch">
+              <div class="circle"></div>
+            </div>
+            <div class="circle-clipper right">
+              <div class="circle"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% if not donators.finished %}
+      <a class="infinite-more-link" id="link"></a>
+    {% endif %}
+  </div>
+</div>
+<script type="text/javascript">
+  const imgError = function () {$(this).attr('src', 'https://www.gravatar.com/avatar/0c69fde20bd613fa206dca3d9996b661?d=mp')};
+  $('img').on("error", imgError)
+  var infinite = new Waypoint.Infinite({
+    element: $('#container').get(0),
+    offset: 'bottom-in-view',
+    onBeforePageLoad: function (element) {
+      $('.loading').show();
+      $('#link').attr('href', `?skip=${$('#container').children().length}`);
+    },
+    onAfterPageLoad: function () {
+      $('.loading').hide();
+      $('img').on("error", imgError)
+    }
+  })
+</script>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path("manifesto/", views.manifesto, name="manifesto"),
     path("colabore/", views.collaborate, name="collaborate"),
     path("doe/", views.donate, name="donate"),
+    path("donators/", views.donators, name="donators"),
     path("contribuidores/", views.contributors, name="contributors"),
     # Dataset-specific pages (specials)
     path("especiais/", views_special.index, name="specials"),

--- a/core/util.py
+++ b/core/util.py
@@ -172,22 +172,19 @@ def create_table_documentation(table):
 
 
 # Brasil.IO on apoiase: "5ab97be3c3f083c623a26742"
-def get_apoiase_donors(campain_id):
+def get_apoiase_donors(campain_id, skip):
     limit = 25  # Max per page
     url = "https://apoia.se/api/v1/users/public-supporters"
-    data = {"campaignId": campain_id, "limit": limit, "skip": 0}
-    finished = False
+    data = {"campaignId": campain_id, "limit": limit, "skip": skip}
     donors = []
-    while not finished:
-        data["skip"] = len(donors)
-        request = Request(
-            url,
-            data=json.dumps(data).encode("utf-8"),
-            method="POST",
-            headers={"Content-Type": "application/json;charset=UTF-8", "User-Agent": USER_AGENT},
-        )
-        response = urlopen(request)
-        new = json.loads(response.read())
-        donors.extend(new)
-        finished = len(new) < limit
-    return donors
+    request = Request(
+        url,
+        data=json.dumps(data).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json;charset=UTF-8", "User-Agent": USER_AGENT},
+    )
+    response = urlopen(request)
+    new = json.loads(response.read())
+    donors.extend(new)
+    finished = len(new) < limit
+    return {'donors': donors, 'finished': finished }

--- a/core/views.py
+++ b/core/views.py
@@ -202,6 +202,5 @@ def contributors(request):
 
 def donators(request):
     skip = request.GET.get('skip', 0)
-    print(skip)
     data = get_apoiase_donors("5ab97be3c3f083c623a26742", int(skip))
     return render(request, "donators.html", {"donators": data })

--- a/core/views.py
+++ b/core/views.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from core.forms import ContactForm, DatasetSearchForm
 from core.models import Dataset, Table
 from core.templatetags.utils import obfuscate
-from core.util import cached_http_get_json
+from core.util import cached_http_get_json, get_apoiase_donors
 
 
 class Echo:
@@ -100,7 +100,7 @@ def dataset_detail(request, slug, tablename=""):
     except Dataset.DoesNotExist:
         context = {"message": "Dataset does not exist"}
         return render(request, "404.html", context, status=404)
-
+    
     if not tablename:
         tablename = dataset.get_default_table().name
         return redirect(reverse("core:dataset-table-detail", kwargs={"slug": slug, "tablename": tablename},))
@@ -199,3 +199,9 @@ def contributors(request):
     url = "https://data.brasil.io/meta/contribuidores.json"
     data = cached_http_get_json(url, 5)
     return render(request, "contributors.html", {"contributors": data})
+
+def donators(request):
+    skip = request.GET.get('skip', 0)
+    print(skip)
+    data = get_apoiase_donors("5ab97be3c3f083c623a26742", int(skip))
+    return render(request, "donators.html", {"donators": data })


### PR DESCRIPTION
Implementação de tela de doadores puxando direto da api e exibindo de 25 em 25 com infinite scroll: Waypoints e infinite-scroll.

1. Adição de página de doadores
2. Adição de link para página de doadores no footer da base
3. Modificações na `core.util.get_apoiase_donors` para considerar doadores já exibidos antes de carregar mais para a tela

#291