### PR TITLE
Cards em /home e /datasets com novo design e animações

### DIFF
--- a/core/templates/dataset-card.html
+++ b/core/templates/dataset-card.html
@@ -1,32 +1,34 @@
 {% load cache %}
 {% cache 600 dataset-card dataset.name table.name %}
-<div class="col m4">
-  <div class="card horizontal small">
-    <div class="card-stacked">
-      <div class="card-content">
-        <span class="card-title activator grey-text text-darken-4">
-          <i class="material-icons fa-1x left">{{ dataset.icon }}</i>
-            <a href="{% url 'core:dataset-detail' dataset.slug %}" title="Ver mais">
-              {{ dataset.name }}
-            </a>
+<div class="col s12 m6 l4 unselectable">
+  <div class="card small hoverable">
+    <div class="card-content-horizontal activator">
+      <div class="center">
+        <i class="material-icons icon-dataset">{{ dataset.icon }}</i>
+      </div>
+      <h3 class="card-title activator">{{ dataset.name }}</h3>
+      <p class="activator">{{ dataset.description }}</p>
+      <div class="center activator">
+        <span class="black-text">
+          <i class="material-icons">keyboard_arrow_up</i>
         </span>
-        <p class="card-description">
-          {{ dataset.description }}
-        </p>
-        <p class="card-dataset-tables">
-          <br>
-          Tabelas:
-          {% for table in dataset.tables %}
-          {% spaceless %}
-          <a href="{% url 'core:dataset-table-detail' dataset.slug table.name %}" title="Ver mais">
-            {% if table.default %}<b>{{ table.name }}</b>
-            {% else %}
-            {{ table.name }}
-            {% endif %}
-          </a>
-          {% endspaceless %}{% if not forloop.last %}, {% endif %}
-          {% endfor %}
-        </p>
+      </div>
+    </div>
+    <div class="card-reveal grey lighten-5">
+      <i class="material-icons icon-dataset">{{ dataset.icon }}</i>
+      <span class="card-title grey-text text-darken-4">Tabelas<i class="material-icons right">close</i></span>
+      <span class="subtitle-tables">{{ dataset.name }}</span>
+      <div class="links">
+        {% for table in dataset.tables %}
+        {% spaceless %}
+        <a href="{% url 'core:dataset-table-detail' dataset.slug table.name %}">
+          {% if table.default %}<b>{{ table.name }}</b>
+          {% else %}
+          {{ table.name }}
+          {% endif %}
+        </a>
+        {% endspaceless %}{% if not forloop.last %} {% endif %}
+        {% endfor %}
       </div>
     </div>
   </div>

--- a/core/templates/dataset-list.html
+++ b/core/templates/dataset-list.html
@@ -2,57 +2,63 @@
 {% block title %}Lista de datasets - Brasil.IO{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col s12 m7">
-    <h4>Datasets</h4>
-  </div>
-  <div class="col s12 m5">
-    <form action="{% url 'core:dataset-list' %}" method='get'>
-      <div class="row">
-        <div class="col s12 m8">
-          {{ form.search.label_tag }}
-          {{ form.search }}
-        </div>
-        <div class="col m-t-15">
-          <button class="btn">Buscar</button>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
+<div class="section">
   <div class="row">
-    <div class="col s12 m-b-15">
-      <div class="divider"></div>
+
+    <div class="col s12 m7">
+      <h1 class="header hide-on-small-only">Datasets</h1>
+      <h1 class="header-small hide-on-med-and-up">Datasets</h1>
+    </div>
+
+    <div class="col s12 m5">
+      <form action="{% url 'core:dataset-list' %}" method='get'>
+        <div class="row">
+          <div class="col s12 m8 input-field">
+            {{ form.search.label_tag }}
+            {{ form.search }}
+          </div>
+          <div class="col m4 m-t-15">
+            <button class="btn">Buscar</button>
+          </div>
+        </div>
+      </form>
     </div>
   </div>
+
+
   <div class="row">
 
-  {% for dataset in datasets %}
+    {% for dataset in datasets %}
     {% include 'dataset-card.html' %}
-  {% endfor %}
+    {% endfor %}
 
-  <div class="col s12 m4 m-t-15">
-    <a href="{% url 'core:dataset-suggestion' %}" title="Ver dataset">
-      <div class="card horizontal small">
-        <div class="card-stacked">
-          <div class="card-content">
-            <span class="card-title activator grey-text text-darken-4">
-              Sugira um dataset
-              <i class="material-icons left">rate_review</i>
-            </span>
-            <p class="card-description">
-              Quais outros dados precisam ser libertados? Sugira aqui.
-            </p>
+    <div class="col s12 m6 l4 unselectable">
+      <div class="card small hoverable">
+        <div class="card-content-horizontal activator hoverable">
+          <div class="center">
+            <i class="material-icons icon-dataset">rate_review</i>
           </div>
-          <div class="card-action indigo-text text-accent-4">
-            <p>
-              <a href="{% url 'core:dataset-suggestion' %}" title="Sugerir"> Sugerir </a>
-            </p>
+          <h3 class="activator">Sugira um dataset</h3>
+          <p class="activator">Quais outros dados precisam ser libertados? Sugira aqui.</p>
+          <div class="center activator">
+            <span class="black-text">
+              <i class="material-icons">keyboard_arrow_up</i>
+            </span>
+          </div>
+        </div>
+        <div class="card-reveal grey lighten-5">
+          <i class="material-icons icon-dataset">{{ dataset.icon }}</i>
+          <span class="card-title grey-text text-darken-4">:)<i class="material-icons right">close</i></span>
+          <span class="subtitle-tables">{{ dataset.name }}</span>
+          <div class="links">
+            <a href="{% url 'core:dataset-suggestion' %}">Sugerir </a>
           </div>
         </div>
       </div>
-    </a>
+    </div>
+
+
+
   </div>
 
 </div>

--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}Home - Brasil.IO{% endblock %}
 {% block top %}
-<div class="top-container indigo darken-1">
+<div class="top-container indigo darken-1 m-b-20">
   <div class="container">
     <div class="section indigo-text text-lighten-5">
       <h3>O Brasil em dados libertos</h3>
@@ -18,94 +18,92 @@
   <section id="info">
 
     <div class="row">
-      <div class="col s12 m12 l12">
-        <div class="card">
-          <div class="card-content teal-text">
-            <span class="card-title">ESPECIAL COVID-19: DADOS POR MUNICÍPIO</span>
+
+      <div class="container">
+        <br>
+        <h1 class="header center green-text hide-on-small-only">ESPECIAL COVID-19: DADOS POR MUNICÍPIO</h1>
+        <h1 class="header-small center green-text hide-on-med-and-up">ESPECIAL COVID-19: DADOS POR MUNICÍPIO</h1>
+        <div style="text-align: justify;" class="row center">
+          <p class="col s12 light">{% include 'covid19-text.html' %}</p>
+        </div>
+        <div class="row center">
+          <a href="{% url 'covid19:dashboard' %}" id="download-button"
+            class="btn-large waves-effect waves-light blue">Ver Mais</a>
+        </div>
+        <br><br>
+
+      </div>
+
+  </section>
+  <div class="row center">
+    <div class="col s12 m6 xl3">
+      <a href="{% url 'core:manifesto' %}">
+        <div class="card small green hoverable waves-block  waves-effect waves-light">
+          <div class="card-content center card-home">
+            <span class="card-title bold white-text">Manifesto</span>
           </div>
-          <div class="card-content card-body">
-            {% include 'covid19-text.html' %}
-          </div>
-          <div class="card-action">
-            <a href="{% url 'covid19:dashboard' %}">Ver mais</a>
+          <div class="card-content card-body white-text" style="text-align:justify;">
+            <p>Venha entender o que motivou a criação do <strong>Brasil.IO</strong> e quais
+              são os objetivos do projeto!</p>
           </div>
         </div>
-      </div>
+      </a>
     </div>
 
-    <div class="row">
-      <div class="col s12 m3">
-        <div class="card">
-          <div class="card-content teal-text">
-            <span class="card-title">Manifesto</span>
+    <div class="col s12 m6 xl3">
+      <a href="{% url 'core:dataset-list' %}">
+        <div class="card small yellow hoverable waves-block  waves-effect waves-orange">
+          <div class="card-content center card-home">
+            <span class="card-title bold black-text">Datasets</span>
           </div>
-          <div class="card-content card-body">
-            <p>Venha entender o que motivou a criação do <strong>Brasil.IO</strong> e quais são os objetivos do projeto!</p>
-          </div>
-          <div class="card-action">
-            <a href="{% url 'core:manifesto' %}">Ver mais</a>
+          <div class="card-content card-body black-text" style="text-align:justify;">
+            <p>Confira a lista completa de todas as base de dados liberadas.</p>
           </div>
         </div>
-      </div>
+      </a>
+    </div>
 
-      <div class="col s12 m3">
-        <div class="card">
-          <div class="card-content teal-text">
-            <span class="card-title">Datasets</span>
+    <div class="col s12 m6 xl3">
+      <a href="{% url 'core:dataset-suggestion' %}">
+        <div class="card small blue darken-1 hoverable waves-block  waves-effect waves-light">
+          <div class="card-content center card-home">
+            <span class="card-title bold white-text">Sugira um Dataset</span>
           </div>
-          <div class="card-content card-body">
-            <p>Confira a lista completa de todas as base de dados liberadas. </p>
-          </div>
-          <div class="card-action">
-            <a href="{% url 'core:dataset-list' %}">Ver mais</a>
-          </div>
-        </div>
-      </div>
-
-      <div class="col s12 m3">
-        <div class="card">
-          <div class="card-content teal-text">
-            <span class="card-title">Sugira um Dataset</span>
-          </div>
-          <div class="card-content card-body">
+          <div class="card-content card-body white-text" style="text-align:justify;">
             <p>Conhece algum dataset bacana que gostaria de ver aqui? Sugira para nós! =)</p>
           </div>
-          <div class="card-action">
-            <a href="{% url 'core:dataset-suggestion' %}">Ver mais</a>
-          </div>
         </div>
-      </div>
-
-      <div class="col s12 m3">
-        <div class="card">
-          <div class="card-content teal-text">
-            <span class="card-title">Colabore</span>
-          </div>
-          <div class="card-content card-body">
-            <p>Achou o projeto legal e quer contribuir? Veja aqui como. </p>
-          </div>
-          <div class="card-action">
-            <a href="https://github.com/turicas/brasil.io/issues">Ver mais</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="datasets">
-    <div class="divider-new pt-3">
-      <h4 class="text-center m-15 dark-blue">Datasets</h4>
+      </a>
     </div>
 
-    {% for dataset in datasets %}
+    <div class="col s12 m6 xl3">
+      <a href="https://github.com/turicas/brasil.io/issues">
+        <div class="card small hoverable waves-block  waves-effect">
+          <div class="card-content center card-home">
+            <span class="card-title bold black-text">Colabore</span>
+          </div>
+          <div class="card-content card-body" style="text-align:justify;">
+            <p class="black-text">Achou o projeto legal e quer contribuir? Clique aqui e veja aqui como.
+            </p>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <section id="datasets" style="margin-top: 50px;">
+    <h4 class="text-center m-15 green-text">Datasets</h4>
+    <div class="row" style="margin-top: 50px;">
+      {% for dataset in datasets %}
       {% include 'dataset-card.html' %}
-    {% endfor %}
+      {% endfor %}
+    </div>
 
-    <div class="row text-center">
-      <a class="btn btn-ptc btn-md waves-effect waves-light" href="{% url 'core:dataset-list' %}" title="Ver Todos Datasets" role="button">
+    <div class="row text-center" style="padding-bottom: 30px;">
+      <a class="btn waves-effect waves-light m-t-20" href="{% url 'core:dataset-list' %}" role="button">
         Ver Todos Datasets
       </a>
-    <div>
+      <div>
   </section>
 
 </div>

--- a/covid19/static/css/covid19-map.css
+++ b/covid19/static/css/covid19-map.css
@@ -97,3 +97,54 @@ nav ul {
     padding: 0 0.25em;
   }
 }
+
+/* 
+  Css para manter style da dashboard covid19
+  com estilos de espaçamento e cards diferentes
+  das outras telas do sistema.
+*/
+.container {
+  padding: 10px;
+}
+
+.card .card-action a:not(.btn):not(.btn-large):not(.btn-small):not(.btn-large):not(.btn-floating) {
+  color: #1A237E !important;
+  margin-right: 10px;
+  -webkit-transition: color .3s ease;
+  transition: color .3s ease;
+  text-transform: uppercase;
+  font-weight: bold;
+}
+
+.card .card-content {
+  padding: 0 0.5em 0.5em 0.5em;
+}
+
+.card .card-title {
+  font-size: 1.5em;
+  font-weight: 300;
+}
+
+.card .card-content.card-body {
+  min-height: 100px;
+}
+
+.card.small .card-description {
+  color: rgba(0,0,0,0.87);
+}
+
+.container {
+  margin: 0 auto;
+  width: 90%;
+  max-width: 100%;
+}
+@media only screen and (min-width: 601px) {
+  .container {
+    width: 90%;
+  }
+}
+@media only screen and (min-width: 993px) {
+  .container {
+    width: 90%;
+  }
+}

--- a/static/css/application.css
+++ b/static/css/application.css
@@ -3,9 +3,7 @@ html {
   box-sizing: border-box;
 }
 
-*,
-*:before,
-*:after {
+*, *:before, *:after {
   box-sizing: inherit;
 }
 
@@ -21,6 +19,14 @@ body {
 
 main {
   flex: 1 0 auto;
+}
+
+.footer {
+  text-align: center;
+}
+
+.footer.indigo a {
+  color: #00a2ec;
 }
 
 .divider-new:before {
@@ -52,43 +58,14 @@ main {
   margin-bottom: 45px;
 }
 
-.divider-new{
+.divider-new {
   font-weight: 300;
-}
-
-.container {
-  padding: 10px;
-}
-
-.card .card-action a:not(.btn):not(.btn-large):not(.btn-small):not(.btn-large):not(.btn-floating) {
-  color: #1A237E !important;
-  margin-right: 10px;
-  -webkit-transition: color .3s ease;
-  transition: color .3s ease;
-  text-transform: uppercase;
-  font-weight: bold;
-}
-
-.card .card-content {
-  padding: 0 0.5em 0.5em 0.5em;
-}
-
-.card .card-title {
-  font-size: 1.5em;
-  font-weight: 300;
-}
-
-.card .card-content.card-body {
-  min-height: 100px;
-}
-
-.card.small .card-description {
-  color: rgba(0,0,0,0.87);
 }
 
 .footer {
   text-align: center;
 }
+
 .footer.indigo a {
   color: #00a2ec;
 }
@@ -132,11 +109,9 @@ ul.social-buttons li a {
   transition: all .3s;
 }
 
-ul.social-buttons li a:hover,
-ul.social-buttons li a:focus,
-ul.social-buttons li a:active {
+ul.social-buttons li a:hover, ul.social-buttons li a:focus, ul.social-buttons li a:active {
   background-color: #3f51b5;
-  color:#fff;
+  color: #fff;
 }
 
 p.contributor-description {
@@ -144,32 +119,132 @@ p.contributor-description {
   margin-bottom: 10px;
 }
 
-.card > .card-content.card-body.number{
-  font-weight: bold;
-  font-size: 1.5em;
-  height: 2em;
-  text-align: center;
-}
-
 h1, h2, h3, h4, h5, h6 {
   margin: 0.5rem 0 0.5rem 0;
 }
 
-.container {
-  margin: 0 auto;
-  width: 90%;
-  max-width: 100%;
-}
-@media only screen and (min-width: 601px) {
-  .container {
-    width: 90%;
-  }
-}
-@media only screen and (min-width: 993px) {
-  .container {
-    width: 90%;
-  }
+strong {
+  font-weight: bold !important;
 }
 
-strong { font-weight: bold !important; }
-em { font-style: italic !important; }
+em {
+  font-style: italic !important;
+}
+
+/* Home */
+
+/* Scroll */
+
+  /* width */
+
+.card ::-webkit-scrollbar {
+  width: 5px;
+}
+
+/* Track */
+
+.card ::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+/* Handle */
+
+.card ::-webkit-scrollbar-thumb {
+  background: #888;
+}
+
+/* Handle on hover */
+
+.card ::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
+.card-home {
+  margin-top: 40px;
+}
+
+.card .card-content-horizontal .icon-dataset {
+  position: absolute;
+  font-size: 120px;
+  opacity: 10%;
+  top: 5%;
+  left: 55%;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
+.card .card-reveal .icon-dataset {
+  position: absolute;
+  font-size: 150px;
+  opacity: 5%;
+  top: 25%;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  text-align: center;
+}
+
+.card-content-horizontal {
+  padding: 50px 15px 21px;
+  overflow: hidden;
+  position: relative;
+}
+
+.card .card-content-horizontal h3 {
+  margin-top: 0px;
+  min-height: 50px;
+  font-size: 1.3em;
+}
+
+.card .card-content-horizontal p {
+  margin-top: 15px;
+  padding-right: 5px;
+  font-size: 0.9em;
+  text-align: justify;
+  min-height: 120px;
+  max-height: 120px;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.links {
+  margin-top: 15px;
+}
+
+.links a {
+  display: block;
+  margin-top: 3px;
+}
+
+.activator {
+  cursor: pointer;
+}
+
+.subtitle-tables {
+  font-size: 0.9em;
+}
+
+.unselectable {
+  -webkit-user-select: none;
+  /* Safari */
+  -moz-user-select: none;
+  /* Firefox */
+  -ms-user-select: none;
+  /* IE10+/Edge */
+  user-select: none;
+  /* Standard */
+}
+
+.header {
+  font-size: 30px;
+}
+
+.header-small {
+  font-size: 20px;
+}
+
+.header-subtitle {
+  font-size: 1.5em;
+}


### PR DESCRIPTION
Como as telas ficaram:

![screencapture-localhost-8000-home-2020-07-14-15_58_11](https://user-images.githubusercontent.com/26860387/87468484-17c79480-c5f0-11ea-827c-246ebbb39261.png)

![screencapture-localhost-8000-datasets-2020-07-14-15_59_19](https://user-images.githubusercontent.com/26860387/87468494-1ac28500-c5f0-11ea-9af9-9d85c5f4772d.png)

Para não quebrar o front do dashboard covid19, passei a parte do css que tratava de espaçamentos e containers de application.css para o arquivo covid19-map.css.