### PR TITLE
Correção de tamanho de fonte de numeros de cards na covid19 dashboard page

### DIFF
--- a/covid19/static/covid19/css/map.css
+++ b/covid19/static/covid19/css/map.css
@@ -27,6 +27,14 @@ nav.nav-state-selector ul {
   height: 10em;
 }
 
+.card > .card-content.card-body.number{
+  font-weight: bold;
+  font-size: 1.5em;
+  height: 2em;
+  text-align: center;
+}
+
+
 .info {
   padding: 6px 8px;
   font: 14px/16px sans-serif;


### PR DESCRIPTION
Na PR #378

Acabou ficando de fora essa classe na hora de passar o css de application.css para covid19-map.css que personaliza o tamanho da fonte na dashboard.