### PR TITLE
Corrige ordem de chamada para invalidar planilhas automáticas

### DIFF
--- a/covid19/commands.py
+++ b/covid19/commands.py
@@ -115,8 +115,8 @@ class UpdateStateTotalsCommand:
         return form.save()
 
     def deploy_spreadsheet(self, spreadsheet, log_prefix):
-        StateSpreadsheet.objects.cancel_older_versions(spreadsheet)
         spreadsheet.import_to_final_dataset(automatically_created=True)
+        StateSpreadsheet.objects.cancel_older_versions(spreadsheet)
         spreadsheet.refresh_from_db()
         message = f"{log_prefix}, id = {spreadsheet.id}"
         self.debug(message)


### PR DESCRIPTION
Esse PR complementa o trabalho de #355. O processo de invalidação deve rodar **depois** de termos importado a planilha automaticamente já que esse processo modifica qual o usuário associado à planilha para o usuário `robo-covid19`.