### PR TITLE
Melhora gerenciamento de DataTables via admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -86,9 +86,6 @@ class DataTableAdmin(admin.ModelAdmin):
     def has_add_permission(self, *args, **kwargs):
         return False
 
-    def has_delete_permission(self, *args, **kwargs):
-        return False
-
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [

--- a/core/admin.py
+++ b/core/admin.py
@@ -86,6 +86,9 @@ class DataTableAdmin(admin.ModelAdmin):
     def has_add_permission(self, *args, **kwargs):
         return False
 
+    def has_delete_permission(self, request, *args, **kwargs):
+        return request.user.is_superuser
+
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,4 +1,6 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect, render
 from django.templatetags.static import static
 from django.utils.html import format_html
 from markdownx.admin import MarkdownxModelAdmin
@@ -72,6 +74,7 @@ class DataTableAdmin(admin.ModelAdmin):
     list_display = ["db_table_name", "dataset", "table", "created_at", "active"]
     list_filter = ["active", "table"]
     readonly_fields = ["db_table_name", "table", "active", "created_at"]
+    ACTIVATE_OP, DEACTIVATE_OP = "activate", "deactivate"
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("table__dataset")
@@ -84,6 +87,64 @@ class DataTableAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, *args, **kwargs):
         return False
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "manage/<int:data_table_id>/<str:op_type>/",
+                self.admin_site.admin_view(self.data_table_management_view),
+                name="data_table_management_view",
+            ),
+        ]
+        return custom_urls + urls
+
+    def data_table_management_view(self, request, data_table_id, op_type):
+        if not request.user.is_superuser:
+            raise Http404
+
+        data_table = get_object_or_404(models.DataTable, pk=data_table_id)
+        context = self.admin_site.each_context(request)
+        context["data_table_repr"] = str(data_table)
+
+        if op_type == self.ACTIVATE_OP:
+            if data_table.active:
+                self.message_user(request, f"{data_table} is already active", messages.WARNING)
+                return redirect("admin:core_datatable_changelist")
+
+            current = data_table.table.data_table
+            context["action_title"] = "Ativar"
+            context[
+                "help_text"
+            ] = f"Ao desempenhar essa ação, <a href='{current.admin_url}'>{current}</a> será inativado."
+            if request.GET.get("confirm", None):
+                data_table.activate()
+                self.message_user(request, f"{data_table} is now active")
+                return redirect(data_table.admin_url)
+
+        elif op_type == self.DEACTIVATE_OP:
+            if not data_table.active:
+                self.message_user(request, f"{data_table} is already not active", messages.WARNING)
+                return redirect("admin:core_datatable_changelist")
+
+            most_recent = data_table.table.data_tables.exclude(id=data_table.id).inactive().most_recent()
+            if most_recent:
+                context[
+                    "help_text"
+                ] = f"Ao desempenhar essa ação, <a href='{most_recent.admin_url}'>{most_recent}</a> será ativado."
+            else:
+                context[
+                    "help_text"
+                ] = f"<b>CUIDADO!!!</b> A tabela {data_table.table} não possui nenhum outro DataTable associado a ela. Desativar esse DataTable pode gerar efeitos indesejados ao sistema."
+
+            context["action_title"] = "Desativar"
+            if request.GET.get("confirm", None):
+                data_table.deactivate(activate_most_recent=True)
+                self.message_user(request, f"{data_table} is now active")
+                return redirect(data_table.admin_url)
+        else:
+            raise Http404
+        return render(request, "admin/data_table_activation_confirm.html", context=context)
 
 
 admin.site.register(models.DataTable, DataTableAdmin)

--- a/core/admin.py
+++ b/core/admin.py
@@ -99,12 +99,13 @@ class DataTableAdmin(admin.ModelAdmin):
 
     def manage_activation(self, obj):
         if obj.active:
-            url = reverse('admin:data_table_management_view', args=[obj.id, self.DEACTIVATE_OP])
+            url = reverse("admin:data_table_management_view", args=[obj.id, self.DEACTIVATE_OP])
             label = "Desativar DataTable"
         else:
-            url = reverse('admin:data_table_management_view', args=[obj.id, self.ACTIVATE_OP])
+            url = reverse("admin:data_table_management_view", args=[obj.id, self.ACTIVATE_OP])
             label = "Ativar DataTable"
         return format_html(f"<a href='{url}'>{label}</a>")
+
     manage_activation.short_description = "Gerenciar ativação/desativação"
 
     def data_table_management_view(self, request, data_table_id, op_type):

--- a/core/admin.py
+++ b/core/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin, messages
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.templatetags.static import static
+from django.urls import path, reverse
 from django.utils.html import format_html
 from markdownx.admin import MarkdownxModelAdmin
 
@@ -71,7 +72,7 @@ admin.site.register(models.Field, FieldAdmin)
 
 class DataTableAdmin(admin.ModelAdmin):
     ordering = ["-active", "db_table_name"]
-    list_display = ["db_table_name", "dataset", "table", "created_at", "active"]
+    list_display = ["db_table_name", "dataset", "table", "created_at", "active", "manage_activation"]
     list_filter = ["active", "table"]
     readonly_fields = ["db_table_name", "table", "active", "created_at"]
     ACTIVATE_OP, DEACTIVATE_OP = "activate", "deactivate"
@@ -98,6 +99,16 @@ class DataTableAdmin(admin.ModelAdmin):
             ),
         ]
         return custom_urls + urls
+
+    def manage_activation(self, obj):
+        if obj.active:
+            url = reverse('admin:data_table_management_view', args=[obj.id, self.DEACTIVATE_OP])
+            label = "Desativar DataTable"
+        else:
+            url = reverse('admin:data_table_management_view', args=[obj.id, self.ACTIVATE_OP])
+            label = "Ativar DataTable"
+        return format_html(f"<a href='{url}'>{label}</a>")
+    manage_activation.short_description = "Gerenciar ativação/desativação"
 
     def data_table_management_view(self, request, data_table_id, op_type):
         if not request.user.is_superuser:

--- a/core/models.py
+++ b/core/models.py
@@ -13,6 +13,7 @@ from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.db import connection, models, transaction
 from django.db.models import F
 from django.db.utils import ProgrammingError
+from django.urls import reverse
 from markdownx.models import MarkdownxField
 from rows import fields as rows_fields
 
@@ -564,6 +565,10 @@ class DataTable(models.Model):
 
     def __str__(self):
         return f"DataTable: {self.db_table_name}"
+
+    @property
+    def admin_url(self):
+        return reverse("admin:core_datatable_change", args=[self.id])
 
     @classmethod
     def new_data_table(cls, table, suffix_size=8):

--- a/core/models.py
+++ b/core/models.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from textwrap import dedent
 from urllib.parse import urlparse
 
-from django.db.models.signals import pre_delete, post_delete
 import django.contrib.postgres.indexes as pg_indexes
 import django.db.models.indexes as django_indexes
 from cachalot.api import invalidate
@@ -13,6 +12,7 @@ from django.contrib.postgres.fields import ArrayField, JSONField
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVectorField
 from django.db import connection, models, transaction
 from django.db.models import F
+from django.db.models.signals import post_delete, pre_delete
 from django.db.utils import ProgrammingError
 from django.urls import reverse
 from markdownx.models import MarkdownxField
@@ -610,7 +610,7 @@ class DataTable(models.Model):
 
 def prevent_active_data_table_deletion(sender, instance, **kwargs):
     if instance.active:
-        msg = f'{instance} is active and can not be deleted. Deactivate it first.'
+        msg = f"{instance} is active and can not be deleted. Deactivate it first."
         raise RuntimeError(msg)
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -5,17 +5,16 @@ from collections import OrderedDict
 from textwrap import dedent
 from urllib.parse import urlparse
 
+import django.contrib.postgres.indexes as pg_indexes
+import django.db.models.indexes as django_indexes
 from cachalot.api import invalidate
 from django.contrib.postgres.fields import ArrayField, JSONField
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVectorField
-from django.db import connection, models
-from django.db import transaction
+from django.db import connection, models, transaction
 from django.db.models import F
 from django.db.utils import ProgrammingError
 from markdownx.models import MarkdownxField
 from rows import fields as rows_fields
-import django.contrib.postgres.indexes as pg_indexes
-import django.db.models.indexes as django_indexes
 
 from core.filters import DynamicModelFilterProcessor
 

--- a/core/models.py
+++ b/core/models.py
@@ -539,7 +539,10 @@ def get_table_model(dataset_slug, tablename):
 
 class DataTableQuerySet(models.QuerySet):
     def get_current_active(self):
-        return self.active().order_by("-created_at").first()
+        return self.active().most_recent()
+
+    def most_recent(self):
+        return self.order_by("-created_at").first()
 
     def inactive(self):
         return self.filter(active=False)

--- a/core/models.py
+++ b/core/models.py
@@ -593,10 +593,10 @@ class DataTable(models.Model):
                 most_recent = self.table.data_tables.exclude(id=self.id).inactive().most_recent()
                 if most_recent:
                     most_recent.activate(drop_inactive_table=drop_table)
-            else:
-                self.active = False
-                self.save()
+                    return
 
+            self.active = False
+            self.save()
             if drop_table:
                 self.delete_data_table()
 

--- a/core/templates/admin/data_table_activation_confirm.html
+++ b/core/templates/admin/data_table_activation_confirm.html
@@ -1,0 +1,43 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block title %}
+{{ action_title }} DataTable
+{{ block.super }}
+{% endblock %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">Início</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label='core' %}">Core</a>
+&rsaquo; <a href="{% url 'admin:core_datatable_changelist' %}">DataTable</a>
+&rsaquo; {{ action_title }} {{ data_table_repr }}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block content %}
+<h1>{{ action_title }} {{ data_table_repr }}</h1>
+
+<div id="content-main">
+  <p><b>Cuidado:</b> operações sobre objetos DataTable afetarão os dados a serem retornados pelo backend do Brasil.io.</p>
+
+  <div class="module aligned">
+    <div class="form-row">
+      <div>
+        <label><b>{{ action_title }} DataTable:</b></label>
+        <div class="object-tools">
+          <a href="./?confirm=True" style="background: red">{{ action_title }} DataTable</a>
+        </div>
+        <div class="help">
+          {{ help_text|safe }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock %}

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -1,11 +1,11 @@
 from collections import OrderedDict
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 from model_bakery import baker, seq
 from rows import fields
 
-from core.models import Table, DataTable, DynamicModelMixin
+from core.models import DataTable, DynamicModelMixin, Table
 
 
 class TableModelTests(TestCase):
@@ -75,34 +75,33 @@ class TableModelTests(TestCase):
 
 
 class DataTableModelTests(TestCase):
-
     def setUp(self):
-        self.table = baker.make(Table, dataset__slug='ds-slug', name='table_name')
+        self.table = baker.make(Table, dataset__slug="ds-slug", name="table_name")
 
     def test_new_datatable_with_table_name_suffix(self):
         data_table = DataTable.new_data_table(self.table)
-        splited_name = data_table.db_table_name.split('_')
+        splited_name = data_table.db_table_name.split("_")
 
         assert not data_table.id  # creates an instance but doesn't save it in the DB
         assert data_table.table == self.table
         assert data_table.active is False
         assert len(splited_name) == 4  # data + ds slug + table + suffix
-        assert splited_name[0] == 'data'
-        assert splited_name[1] == 'dsslug'
-        assert splited_name[2] == 'tablename'
+        assert splited_name[0] == "data"
+        assert splited_name[1] == "dsslug"
+        assert splited_name[2] == "tablename"
         assert len(splited_name[3]) == 8  # suffix with 8 chars
 
     def test_new_datatable_without_table_name_suffix(self):
         data_table = DataTable.new_data_table(self.table, suffix_size=0)
-        splited_name = data_table.db_table_name.split('_')
+        splited_name = data_table.db_table_name.split("_")
 
         assert not data_table.id  # creates an instance but doesn't save it in the DB
         assert data_table.table == self.table
         assert data_table.active is False
         assert len(splited_name) == 3  # data + ds slug + table
-        assert splited_name[0] == 'data'
-        assert splited_name[1] == 'dsslug'
-        assert splited_name[2] == 'tablename'
+        assert splited_name[0] == "data"
+        assert splited_name[1] == "dsslug"
+        assert splited_name[2] == "tablename"
 
     def test_activate_data_table(self):
         data_table = DataTable.new_data_table(self.table)
@@ -112,7 +111,7 @@ class DataTableModelTests(TestCase):
 
         assert data_table.active is True
 
-    @patch.object(Table, 'get_model', Mock())
+    @patch.object(Table, "get_model", Mock())
     def test_activate_data_table_updates_previous_active_as_inactive(self):
         old_data_table = DataTable.new_data_table(self.table)
         old_data_table.activate()
@@ -127,7 +126,7 @@ class DataTableModelTests(TestCase):
         assert new_data_table.active is True
         assert self.table.get_model.called is False
 
-    @patch.object(Table, 'get_model', Mock(DynamicModelMixin))
+    @patch.object(Table, "get_model", Mock(DynamicModelMixin))
     def test_activate_data_table_updates_previous_active_as_inactive_and_delete_table_if_flagged(self):
         old_data_table = DataTable.new_data_table(self.table)
         old_data_table.activate()

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -142,3 +142,33 @@ class DataTableModelTests(TestCase):
         self.table.get_model.assert_called_once_with(cache=False, data_table=old_data_table)
         Model = self.table.get_model(cache=False, data_table=old_data_table)
         Model.delete_table.assert_called_once_with()
+
+    def test_deactivate_does_not_handle_activation_by_default(self):
+        old_data_table = DataTable.new_data_table(self.table)
+        old_data_table.activate()
+        new_data_table = DataTable.new_data_table(self.table)
+        new_data_table.activate()
+
+        new_data_table.deactivate()
+        old_data_table.refresh_from_db()
+        new_data_table.refresh_from_db()
+
+        assert old_data_table.active is False
+        assert new_data_table.active is False
+
+    def test_deactivate_activates_most_recent_if_flag(self):
+        oldest_data_table = DataTable.new_data_table(self.table)
+        oldest_data_table.activate()
+        old_data_table = DataTable.new_data_table(self.table)
+        old_data_table.activate()
+        new_data_table = DataTable.new_data_table(self.table)
+        new_data_table.activate()
+
+        new_data_table.deactivate(activate_most_recent=True)
+        oldest_data_table.refresh_from_db()
+        old_data_table.refresh_from_db()
+        new_data_table.refresh_from_db()
+
+        assert oldest_data_table.active is False
+        assert new_data_table.active is False
+        assert old_data_table.active is True


### PR DESCRIPTION
Fixes #382 

Esse PR introduz:

1. Nova coluna na listagem de `DataTable` linkando para página de ativação/desativação;
2. Mecanismo para ativar/desativar um DataTable;
3. Controle de deleção de DataTable apagando também as tabelas no banco de dados;