### PR TITLE
Implementa rate limit para a páginda de dados de um dataset

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -166,6 +166,11 @@ if THROTTLING_RATE:
         }
     )
 
+RATELIMIT_ENABLE = env("RATELIMIT_ENABLE", cast=bool, default=False)
+RATELIMIT_RATE = env(
+    "RATELIMIT_RATE", default="10/m"
+)  # we have to force a default value, otherwise django-ratelimit breaks our app
+
 CORS_ORIGIN_ALLOW_ALL = True
 
 

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -58,7 +58,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
-if DEBUG:
+if DEBUG and env("DEBUG_SQL", cast=bool, default=True):
     MIDDLEWARE.append("utils.sqlprint.SqlPrintingMiddleware")
 
 ROOT_URLCONF = "brasilio.urls"

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -225,8 +225,6 @@ CACHES = {
         "KEY_PREFIX": env("CACHE_KEY_PREFIX"),
     }
 }
-if DEBUG:
-    CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache",}}
 
 # django-rq config
 RQ_QUEUES = {"default": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 500,}}

--- a/brasilio/test_settings.py
+++ b/brasilio/test_settings.py
@@ -7,3 +7,4 @@ for queue in RQ_QUEUES.values():  # noqa
 
 
 SAMPLE_SPREADSHEETS_DATA_DIR = Path(BASE_DIR).joinpath("covid19", "tests", "data")  # noqa
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache",}}  # noqa

--- a/brasilio/test_settings.py
+++ b/brasilio/test_settings.py
@@ -8,3 +8,5 @@ for queue in RQ_QUEUES.values():  # noqa
 
 SAMPLE_SPREADSHEETS_DATA_DIR = Path(BASE_DIR).joinpath("covid19", "tests", "data")  # noqa
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache",}}  # noqa
+
+RATELIMIT_ENABLE = False  # noqa

--- a/brasilio/urls.py
+++ b/brasilio/urls.py
@@ -12,3 +12,5 @@ urlpatterns = [
     path("markdownx/", include("markdownx.urls")),
     path("", include("core.urls", namespace="core")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+handler403 = "core.handlers.handler_403"

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -1,0 +1,20 @@
+from django.shortcuts import render
+from ratelimit.exceptions import Ratelimited
+
+rate_limit_msg = """
+<p>Você atingiu o limite de requisições e, por isso, essa requisição foi bloqueada. Caso você precise acessar várias páginas de um dataset, por favor, baixe o dataset completo em vez de percorrer várias páginas na interface (o link para baixar o arquivo completo encontra-se na <a href="https://brasil.io/datasets/">página do dataset</a>).</p>
+<p>Utilizar a interface do Brasil.io via web crawlers e de maneira não otimizada onera muito nossos servidores e atrapalha a experiência de outros usuários. Se o abuso continuar, precisaremos restringir ainda mais os limites de requisições e não gostaríamos de fazer isso.</p>
+<p>Lembre-se: o Brasil.IO é um projeto colaborativo, desenvolvido por voluntários e mantido por financiamento coletivo, você pode doar na <a href="https://apoia.se/brasilio">página do projeto no Apoia.se</a>.</p>
+""".strip()
+
+
+def handler_403(request, exception):
+    """
+    Handler to deal with Ratelimited exception as exepcted. Reference:
+    https://django-ratelimit.readthedocs.io/en/stable/usage.html#exceptions
+    """
+    context = {}
+    status = 403
+    if isinstance(exception, Ratelimited):
+        status, context["message"] = 429, rate_limit_msg
+    return render(request, "403.html", context, status=status)

--- a/core/templates/403.html
+++ b/core/templates/403.html
@@ -6,8 +6,12 @@
     <h1>500</h1>
     <p>
       <b>
+        {% if message %}
+          {{ message|safe }}
+        {% else %}
         Oops! Parece que você não tem permissão para acessar essa página.
         não se preocupe que já fomos notificados e trabalharemos para corrigir.
+        {% endif %}
       </b>
     </p>
     <p>

--- a/core/tests/test_util.py
+++ b/core/tests/test_util.py
@@ -1,0 +1,39 @@
+import pytest
+from django.test import RequestFactory
+
+from core.util import ratelimit_key
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+def test_ratelimit_key_from_cloudfare_ip_with_user_agent(request_factory):
+    ip, user_agent = "127.1.1.0", "test"
+
+    request = request_factory.get("/", HTTP_CF_CONNECTING_IP=ip, HTTP_USER_AGENT=user_agent)
+    key = ratelimit_key("group", request)
+    assert f"{ip}:{user_agent}" == key
+
+
+def test_ratelimit_key_from_x_forwarded_for_ip_with_user_agent(request_factory):
+    ip, user_agent = "127.1.1.0,extra_data", "test"
+
+    request = request_factory.get("/", HTTP_X_FORWARDED_FOR=ip, HTTP_USER_AGENT=user_agent)
+    key = ratelimit_key("group", request)
+    assert f"127.1.1.0:{user_agent}" == key
+
+
+def test_ratelimit_key_from_remote_addr_with_user_agent(request_factory):
+    ip, user_agent = "127.1.1.0", "test"
+
+    request = request_factory.get("/", REMOTE_ADDR=ip, HTTP_USER_AGENT=user_agent)
+    key = ratelimit_key("group", request)
+    assert f"{ip}:{user_agent}" == key
+
+
+def test_fail_safe_if_no_explicit_headers(request_factory):
+    request = request_factory.get("/")
+    key = ratelimit_key("group", request)
+    assert "127.0.0.1:" == key

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -2,10 +2,10 @@ from django.core.management import call_command
 from django.test import override_settings
 from django.urls import reverse
 
-from core.tests.utils import TestCaseWithSampleDataset
+from core.tests.utils import BaseTestCaseWithSampleDataset
 
 
-class SampleDatasetDetailView(TestCaseWithSampleDataset):
+class SampleDatasetDetailView(BaseTestCaseWithSampleDataset):
     DATASET_SLUG = "sample"
     TABLE_NAME = "sample_table"
     FIELDS_KWARGS = [

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -1,0 +1,30 @@
+from django.core.management import call_command
+from django.test import override_settings
+from django.urls import reverse
+
+from core.tests.utils import TestCaseWithSampleDataset
+
+
+class SampleDatasetDetailView(TestCaseWithSampleDataset):
+    DATASET_SLUG = "sample"
+    TABLE_NAME = "sample_table"
+    FIELDS_KWARGS = [
+        {"name": "sample_field", "options": {"max_length": 10}, "type": "text", "null": False},
+    ]
+
+    def setUp(self):
+        self.url = reverse("core:dataset-table-detail", args=["sample", "sample_table"])
+        call_command("clear_cache")
+
+    def test_display_dataset_table_data_with_expected_template(self):
+        response = self.client.get(self.url)
+        assert 200 == response.status_code
+        self.assertTemplateUsed(response, "dataset-detail.html")
+
+    @override_settings(RATELIMIT_ENABLE=True)
+    @override_settings(RATELIMIT_RATE="0/s")
+    def test_enforce_rate_limit_if_flagged(self):
+        response = self.client.get(self.url)
+        assert 429 == response.status_code
+        self.assertTemplateUsed(response, "403.html")
+        assert "Você atingiu o limite de requisições" in response.context["message"]

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -1,0 +1,52 @@
+from django.db.utils import ProgrammingError
+from django.test import TestCase
+from model_bakery import baker
+
+from core.models import Dataset, DataTable
+
+
+class TestCaseWithSampleDataset(TestCase):
+    """
+    Base test case class to prepare Brasil.io's DB to have a sample dataset.
+
+    Must define the class attributes DATASET_SLUG, TABLE_NAME and FIELDS_KWARGS to inherit and use it
+    """
+
+    DATASET_SLUG = ""
+    TABLE_NAME = ""
+    FIELDS_KWARGS = []
+
+    @classmethod
+    def validate_config(cls):
+        required_attrs = ["DATASET_SLUG", "TABLE_NAME", "FIELDS_KWARGS"]
+        name = cls.__name__
+
+        for attr in required_attrs:
+            if not getattr(cls, attr, None):
+                raise ValueError(f"{name}.{attr} cannot be empty")
+
+        is_iterable = issubclass(type(cls.FIELDS_KWARGS), (list, tuple, set))
+        if not (is_iterable and all(type(kw) is dict for kw in cls.FIELDS_KWARGS)):
+            raise ValueError(
+                f"{name}.FIELDS_KWARGS must be an iterable with model fields' description dicts, not {type(cls.FIELDS_KWARGS).__name__}"
+            )
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.validate_config()
+        Dataset.objects.filter(slug=cls.DATASET_SLUG).delete()
+        cls.dataset = baker.make(Dataset, slug=cls.DATASET_SLUG)
+        cls.table = baker.make("core.Table", dataset=cls.dataset, name=cls.TABLE_NAME)
+        cls.data_table = DataTable.new_data_table(cls.table)
+        cls.data_table.activate()
+
+        for f_kwargs in cls.FIELDS_KWARGS:
+            baker.make("core.Field", dataset=cls.dataset, table=cls.table, **f_kwargs)
+
+        cls.TableModel = cls.table.get_model(cache=False)
+        try:
+            cls.TableModel.delete_table()
+        except ProgrammingError:  # Does not exist
+            pass
+        finally:
+            cls.TableModel.create_table(create_indexes=False)

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -5,7 +5,7 @@ from model_bakery import baker
 from core.models import Dataset, DataTable
 
 
-class TestCaseWithSampleDataset(TestCase):
+class BaseTestCaseWithSampleDataset(TestCase):
     """
     Base test case class to prepare Brasil.io's DB to have a sample dataset.
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,9 +1,22 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.urls import path, reverse_lazy
+from ratelimit.decorators import ratelimit
+
+from core.util import ratelimit_key
 
 from . import views, views_special
 
 sign_up_url = reverse_lazy("brasilio_auth:sign_up")
+
+
+def limited_dataset_detail(request, slug, tablename):
+    # cannot use @decorator syntax because reading from settings during import time
+    # prevents django.test.override_settings from working as expected.
+    # that's why I'm manually decorating the view in this custom view
+    return ratelimit(key=ratelimit_key, rate=settings.RATELIMIT_RATE, block=settings.RATELIMIT_ENABLE)(
+        views.dataset_detail
+    )(request, slug, tablename)
 
 
 app_name = "core"
@@ -14,7 +27,7 @@ urlpatterns = [
     path("datasets/", views.dataset_list, name="dataset-list"),
     path("home/", views.home, name="home"),
     path("dataset/<slug>/", views.dataset_detail, name="dataset-detail"),
-    path("dataset/<slug>/<tablename>/", views.dataset_detail, name="dataset-table-detail"),
+    path("dataset/<slug>/<tablename>/", limited_dataset_detail, name="dataset-table-detail"),
     path("datasets/sugira/", views.dataset_suggestion, name="dataset-suggestion"),
     path("manifesto/", views.manifesto, name="manifesto"),
     path("colabore/", views.collaborate, name="collaborate"),

--- a/core/util.py
+++ b/core/util.py
@@ -191,3 +191,17 @@ def get_apoiase_donors(campain_id):
         donors.extend(new)
         finished = len(new) < limit
     return donors
+
+
+def ratelimit_key(group, request):
+    ip = request.META.get("HTTP_CF_CONNECTING_IP", "").strip()
+    if not ip:
+        ip = request.META.get("HTTP_X_FORWARDED_FOR", "").strip()
+        if not ip:
+            ip = request.META.get("REMOTE_ADDR", "").strip()
+        else:
+            ip = ip.split(",")[0]
+
+    agent = request.META.get("HTTP_USER_AGENT", "")
+    key = f"{ip}:{agent}"
+    return key

--- a/core/views.py
+++ b/core/views.py
@@ -142,7 +142,10 @@ def dataset_detail(request, slug, tablename=""):
         if not any([query, search_query]) or not user_agent or block_agent:
             # User trying to download a CSV without custom filters or invalid
             # user-agent specified.
-            context = {"html_code_snippet": "400-csv-without-filters.html", "download_url": table.version.download_url}
+            context = {
+                "html_code_snippet": "400-csv-without-filters.html",
+                "download_url": table.version.download_url,
+            }
             return render(request, "404.html", context, status=400)
 
         if all_data.count() > settings.CSV_EXPORT_MAX_ROWS:

--- a/covid19/tests/test_spreadsheet_validator.py
+++ b/covid19/tests/test_spreadsheet_validator.py
@@ -500,8 +500,8 @@ class TestValidateSpreadsheetWithHistoricalData(Covid19DatasetTestCase):
 
     def test_can_create_covid_19_cases_entries(self):
         table = Table.objects.for_dataset("covid19").named("caso")
-        assert table == self.cases_table
-        Covid19Cases = self.Covid19Cases
+        assert table == self.table
+        Covid19Cases = self.TableModel
 
         assert 0 == len(Covid19Cases.objects.all())
         cases_entry = baker.make(Covid19Cases, _fill_optional=["city"])

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -1,10 +1,12 @@
 import json
 from unittest.mock import patch
 
+from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 
 from covid19.exceptions import SpreadsheetValidationErrors
+from covid19.tests.utils import Covid19DatasetTestCase
 
 
 class ImportSpreadsheetProxyViewTests(TestCase):
@@ -39,3 +41,14 @@ class ImportSpreadsheetProxyViewTests(TestCase):
 
         assert 400 == response.status_code
         assert ["error 1", "error 2"] == sorted(response.json()["errors"])
+
+
+class Covid19DatasetDetailView(Covid19DatasetTestCase):
+    def setUp(self):
+        self.url = reverse("core:dataset-table-detail", args=["covid19", "caso"])
+        call_command("clear_cache")
+
+    def test_display_dataset_table_data_with_expected_template(self):
+        response = self.client.get(self.url)
+        assert 200 == response.status_code
+        self.assertTemplateUsed(response, "dataset-detail.html")

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -1,12 +1,10 @@
 import json
 from unittest.mock import patch
 
-from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 from covid19.exceptions import SpreadsheetValidationErrors
-from covid19.tests.utils import Covid19DatasetTestCase
 
 
 class ImportSpreadsheetProxyViewTests(TestCase):
@@ -41,22 +39,3 @@ class ImportSpreadsheetProxyViewTests(TestCase):
 
         assert 400 == response.status_code
         assert ["error 1", "error 2"] == sorted(response.json()["errors"])
-
-
-class Covid19DatasetDetailView(Covid19DatasetTestCase):
-    def setUp(self):
-        self.url = reverse("core:dataset-table-detail", args=["covid19", "caso"])
-        call_command("clear_cache")
-
-    def test_display_dataset_table_data_with_expected_template(self):
-        response = self.client.get(self.url)
-        assert 200 == response.status_code
-        self.assertTemplateUsed(response, "dataset-detail.html")
-
-    @override_settings(RATELIMIT_ENABLE=True)
-    @override_settings(RATELIMIT_RATE="0/s")
-    def test_enforce_rate_limit_if_flagged(self):
-        response = self.client.get(self.url)
-        assert 429 == response.status_code
-        self.assertTemplateUsed(response, "403.html")
-        assert "Você atingiu o limite de requisições" in response.context["message"]

--- a/covid19/tests/utils.py
+++ b/covid19/tests/utils.py
@@ -1,7 +1,7 @@
-from core.tests.utils import TestCaseWithSampleDataset
+from core.tests.utils import BaseTestCaseWithSampleDataset
 
 
-class Covid19DatasetTestCase(TestCaseWithSampleDataset):
+class Covid19DatasetTestCase(BaseTestCaseWithSampleDataset):
     """
     Base test case class to prepare Brasil.io's DB to have Covid-19 cases dataset.
     """

--- a/env.example
+++ b/env.example
@@ -13,6 +13,7 @@ BLOCKED_AGENTS="Wget,curl,python-requests,Python-urllib"
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:39001/brasilio
 DATA_URL="https://docs.google.com/spreadsheets/d/1-hw07Q7PBGlz2QjOifkwM3T8406OqsGOAWA-fikgW8c/export?format=xlsx"
 DEBUG=True
+DEBUG_SQL=True
 PRODUCTION=False
 SECRET_KEY=012345678901234567890123456789
 EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend

--- a/env.example
+++ b/env.example
@@ -35,6 +35,8 @@ WORKERS=4
 DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage"
 STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage"
 THROTTLING_RATE=""
+RATELIMIT_ENABLE=False
+RATELIMIT_RATE="50/m"
 
 # If using AWS storage, you'll have to populate these values
 AWS_ACCESS_KEY_ID=""

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ xlwt
 retry==0.9.2
 whitenoise==5.0.1
 sorl-thumbnail==12.6.3
+django-ratelimit==3.0.1


### PR DESCRIPTION
@turicas subi [este vídeo com a demo da funcionalidade](https://www.youtube.com/watch?v=d7drNsShano) rodando no meu ambiente local. Para ativar isso em produção, você deverá executar algo parecido com o seguinte comando no server (não me lembro 100% da ordem do CLI do `dokku`):

```bash
dokku brasilio-web config:set RATELIMIT_ENABLE=True RATELIMIT_RATE="10/m" --no-restart
```

Lembrando que o formato do `RATELIMIT_RATE` deve estar de acordo com [os padrões da lib descrito na documentação](https://django-ratelimit.readthedocs.io/en/stable/rates.html#simple-rates).
