### PR TITLE
Remove warnings do processo de deploy

### DIFF
--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm as DjangoUserCreationForm
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from brasilio_auth.models import NewsletterSubscriber
 

--- a/core/dynamic_models.py
+++ b/core/dynamic_models.py
@@ -2,7 +2,6 @@ from textwrap import dedent
 
 import django.contrib.postgres.indexes as pg_indexes
 import django.db.models.indexes as django_indexes
-from django.contrib.postgres.fields import JSONField
 from django.db import connection, models
 
 FIELD_TYPES = {
@@ -14,7 +13,7 @@ FIELD_TYPES = {
     "email": models.EmailField,
     "float": models.FloatField,
     "integer": models.IntegerField,
-    "json": JSONField,
+    "json": models.JSONField,
     "string": models.CharField,  # TODO: rename to "char"
     "text": models.TextField,
 }

--- a/core/models.py
+++ b/core/models.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 import django.contrib.postgres.indexes as pg_indexes
 import django.db.models.indexes as django_indexes
 from cachalot.api import invalidate
-from django.contrib.postgres.fields import ArrayField, JSONField
+from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVectorField
 from django.db import connection, models, transaction
 from django.db.models import F
@@ -268,7 +268,7 @@ class Table(models.Model):
     dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE, null=False, blank=False)
     default = models.BooleanField(null=False, blank=False)
     name = models.CharField(max_length=255, null=False, blank=False)
-    options = JSONField(null=True, blank=True)
+    options = models.JSONField(null=True, blank=True)
     ordering = ArrayField(models.CharField(max_length=63), null=False, blank=False)
     filtering = ArrayField(models.CharField(max_length=63), null=True, blank=True)
     search = ArrayField(models.CharField(max_length=63), null=True, blank=True)
@@ -405,7 +405,7 @@ class Field(models.Model):
 
     TYPE_CHOICES = [(value, value) for value in dynamic_models.FIELD_TYPES.keys()]
 
-    choices = JSONField(null=True, blank=True)
+    choices = models.JSONField(null=True, blank=True)
     dataset = models.ForeignKey(Dataset, on_delete=models.CASCADE, null=False, blank=False)
     description = models.TextField(null=True, blank=True)
     frontend_filter = models.BooleanField(null=False, blank=True, default=False)
@@ -414,7 +414,7 @@ class Field(models.Model):
     order = models.PositiveIntegerField(null=False, blank=False)
     null = models.BooleanField(null=False, blank=True, default=True)
     name = models.CharField(max_length=63)
-    options = JSONField(null=True, blank=True)
+    options = models.JSONField(null=True, blank=True)
     obfuscate = models.BooleanField(null=False, blank=True, default=False)
     show = models.BooleanField(null=False, blank=True, default=True)
     show_on_frontend = models.BooleanField(null=False, blank=True, default=False)

--- a/core/tests/test_filters.py
+++ b/core/tests/test_filters.py
@@ -10,7 +10,7 @@ class TestDynamicModelFilter(TestCase):
 
         filter_processor = DynamicModelFilterProcessor(filtering, allowed_filters)
 
-        self.assertEquals(filter_processor.filters, filtering)
+        self.assertEqual(filter_processor.filters, filtering)
 
     def test_remove_filter_not_allowed(self):
         filtering = {"foo": "bar", "fu": "bá"}
@@ -19,7 +19,7 @@ class TestDynamicModelFilter(TestCase):
         filter_processor = DynamicModelFilterProcessor(filtering, allowed_filters)
 
         expected = {"foo": "bar"}
-        self.assertEquals(filter_processor.filters, expected)
+        self.assertEqual(filter_processor.filters, expected)
 
     def test_remove_None_filter(self):
         filtering = {"foo": "bar", "fu": None}
@@ -28,7 +28,7 @@ class TestDynamicModelFilter(TestCase):
         filter_processor = DynamicModelFilterProcessor(filtering, allowed_filters)
 
         expected = {"foo": "bar"}
-        self.assertEquals(filter_processor.filters, expected)
+        self.assertEqual(filter_processor.filters, expected)
 
     def test_clean_bool_lowercase_values(self):
         filtering = {"foo": "true", "fu": "false"}
@@ -37,7 +37,7 @@ class TestDynamicModelFilter(TestCase):
         filter_processor = DynamicModelFilterProcessor(filtering, allowed_filters)
 
         expected = {"foo": True, "fu": False}
-        self.assertEquals(filter_processor.filters, expected)
+        self.assertEqual(filter_processor.filters, expected)
 
     def test_clean_string_None_to_isnull(self):
         filtering = {"foo": "bar", "fu": "bá", "none": "None"}
@@ -46,4 +46,4 @@ class TestDynamicModelFilter(TestCase):
         filter_processor = DynamicModelFilterProcessor(filtering, allowed_filters)
 
         expected = {"foo": "bar", "fu": "bá", "none__isnull": True}
-        self.assertEquals(filter_processor.filters, expected)
+        self.assertEqual(filter_processor.filters, expected)

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.postgres.fields import ArrayField, JSONField
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.urls import reverse
 from localflavor.br.br_states import STATE_CHOICES
@@ -172,7 +172,7 @@ class StateSpreadsheet(models.Model):
     # precisar ler o arquivo (o validador da planilha no form vai ter que fazer
     # essa leitura, então ele faz, se estiver tudo ok já salva nesse campo pro
     # worker já trabalhar com os dados limpos e normalizados)
-    data = JSONField(default=default_data_json)
+    data = models.JSONField(default=default_data_json)
 
     # por padrao é False, mas vira True se um mesmo usuário subir uma planilha
     # pro mesmo estado pra mesma data (ele cancela o upload anterior pra essa
@@ -356,7 +356,7 @@ class DailyBulletin(models.Model):
     created_at = models.DateField(auto_now_add=True)
     date = models.DateField(unique=True)
     image_url = models.URLField()
-    detailed_data = JSONField(default=dict, blank=True)
+    detailed_data = models.JSONField(default=dict, blank=True)
 
     def __str__(self):
         return f"Boletim: {self.date.day}/{self.date.month}/{self.date.year}"


### PR DESCRIPTION
Fixes #387

Aproveitei e limpei alguns warnings que surgiam no nosso código ao rodar os testes. Ficaram alguns outros porque são warnings que surgem do código das libs que estamos usando.