### PR TITLE
Adiciona property name ao mixin de empresa

### DIFF
--- a/core/data_models.py
+++ b/core/data_models.py
@@ -38,6 +38,10 @@ class SociosBrasilEmpresaMixin:
     def is_headquarter(self):
         return self.cnpj[:12].endswith("0001")
 
+    @property
+    def name(self):
+        return self.razao_social if self.razao_social else self.cnpj
+
 
 class SociosBrasilEmpresaQuerySet(DatasetTableModelQuerySet):
     def branches(self, document):

--- a/core/data_models.py
+++ b/core/data_models.py
@@ -40,7 +40,11 @@ class SociosBrasilEmpresaMixin:
 
     @property
     def name(self):
-        return self.razao_social if self.razao_social else self.cnpj
+        keys_to_try = ("razao_social", "nome_fantasia", "cnpj")
+        for key in keys_to_try:
+            value = str(getattr(self, key, None) or "").strip()
+            if value:
+                return value
 
 
 class SociosBrasilEmpresaQuerySet(DatasetTableModelQuerySet):

--- a/core/tests/test_data_models.py
+++ b/core/tests/test_data_models.py
@@ -20,6 +20,7 @@ class SociosBrasilEmpresaModelTests(BaseTestCaseWithSampleDataset):
     FIELDS_KWARGS = [
         {"name": "cnpj", "options": {"max_length": 14}, "type": "string", "null": False},
         {"name": "razao_social", "type": "text", "null": False},
+        {"name": "nome_fantasia", "type": "text", "null": False},
     ]
 
     def setUp(self):
@@ -60,8 +61,11 @@ class SociosBrasilEmpresaModelTests(BaseTestCaseWithSampleDataset):
 
     def test_empresa_has_a_name_property(self):
         assert self.matriz.razao_social == self.matriz.name
-        # defaults to CNPJ if no data
-        self.matriz.razao_social = ""
+        # defaults to nome_fantasia if no razao_social
+        self.matriz.razao_social = " "
+        assert self.matriz.nome_fantasia == self.matriz.name
+        # defaults to cnpj if no razao_social and nome_fantasia
+        self.matriz.nome_fantasia = " "
         assert self.matriz.cnpj == self.matriz.name
 
 

--- a/core/tests/test_data_models.py
+++ b/core/tests/test_data_models.py
@@ -19,6 +19,7 @@ class SociosBrasilEmpresaModelTests(BaseTestCaseWithSampleDataset):
     TABLE_NAME = "empresa"
     FIELDS_KWARGS = [
         {"name": "cnpj", "options": {"max_length": 14}, "type": "string", "null": False},
+        {"name": "razao_social", "type": "text", "null": False},
     ]
 
     def setUp(self):
@@ -56,6 +57,12 @@ class SociosBrasilEmpresaModelTests(BaseTestCaseWithSampleDataset):
         self.filial.delete()
         with pytest.raises(self.Empresa.DoesNotExist):
             self.Empresa.objects.get_headquarter_or_branch(document)
+
+    def test_empresa_has_a_name_property(self):
+        assert self.matriz.razao_social == self.matriz.name
+        # defaults to CNPJ if no data
+        self.matriz.razao_social = ""
+        assert self.matriz.cnpj == self.matriz.name
 
 
 class EmpresaTableConfigTest(BaseTestCaseWithSampleDataset):


### PR DESCRIPTION
(Resolve issue 221 do Sentry) A partir do commit cee776c531526696d9324c72cce52ed4fd4a64d2 o
a tabela de documents do dataset socios-brasil foi subsitituído
pela nova tabela empresa. Isso incidiu em algumas ocorrências de
exceções 'SociosBrasilEmpresa' object has no attribute 'name' no
Sentry. Isso se deu porque, apesar de termos modificado a tabela
que está sendo usada, o código ainda se relaciona com a API da
tabela antiga de documentos e que possuía um atributo `name`.

Nesse commit escapo desse problema com essa property que, tenta
primeiro retornar o campo de razão social da empresa. Caso ele não
tenha dados ou esteja vazio, retornamos o próprio CNPJ.