### PR TITLE
Trata erros de 429 a nível de middleware diminuindo o processamento da request

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -51,8 +51,8 @@ INSTALLED_APPS = [
     "rangefilter",
 ]
 MIDDLEWARE = [
-    "traffic_control.middlewares.block_suspicious_requests",
     "django.middleware.security.SecurityMiddleware",
+    "traffic_control.middlewares.block_suspicious_requests",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/brasilio/test_settings.py
+++ b/brasilio/test_settings.py
@@ -5,11 +5,6 @@ from .settings import *  # noqa
 for queue in RQ_QUEUES.values():  # noqa
     queue["ASYNC"] = False
 
-
-block_middleware = "traffic_control.middlewares.block_suspicious_requests"  # noqa
-if block_middleware in MIDDLEWARE:  # noqa
-    MIDDLEWARE.remove(block_middleware)  # noqa
-
 SAMPLE_SPREADSHEETS_DATA_DIR = Path(BASE_DIR).joinpath("covid19", "tests", "data")  # noqa
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache",}}  # noqa
 RQ_BLOCKED_REQUESTS_LIST = ""

--- a/brasilio_auth/tests/test_views.py
+++ b/brasilio_auth/tests/test_views.py
@@ -6,13 +6,15 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
-from traffic_control.tests.util import REQUIRED_HEADERS
+from traffic_control.tests.util import TrafficControlClient
 
 User = get_user_model()
 
 
 @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
 class UserCreationViewTests(TestCase):
+    client_class = TrafficControlClient
+
     def setUp(self):
         self.url = reverse("brasilio_auth:sign_up")
         passwd = "someverygoodpassword"
@@ -25,12 +27,12 @@ class UserCreationViewTests(TestCase):
         }
 
     def test_render_correct_template(self):
-        response = self.client.get(self.url, **REQUIRED_HEADERS)
+        response = self.client.get(self.url)
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         assert "form" in response.context
 
     def test_render_form_errors_if_invalid_post(self):
-        response = self.client.post(self.url, data={}, **REQUIRED_HEADERS)
+        response = self.client.post(self.url, data={})
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         assert bool(response.context["form"].errors) is True
 
@@ -38,7 +40,7 @@ class UserCreationViewTests(TestCase):
         assert 1 == User.objects.count()  # auto import covid 19 user
         assert User.objects.filter(username=settings.COVID19_AUTO_IMPORT_USER).exists()
 
-        response = self.client.post(self.url, data=self.data, **REQUIRED_HEADERS)
+        response = self.client.post(self.url, data=self.data)
         user = User.objects.get(username="foo")
 
         self.assertRedirects(response, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False)
@@ -46,12 +48,12 @@ class UserCreationViewTests(TestCase):
         assert str(user.pk) == self.client.session["_auth_user_id"]
 
     def test_form_error_if_trying_to_create_user_with_existing_username(self):
-        response = self.client.post(self.url, data=self.data, **REQUIRED_HEADERS)
+        response = self.client.post(self.url, data=self.data)
         assert User.objects.filter(username="foo").exists()
 
         self.data["username"] = "FOO"
         self.data["email"] = "new@foo.com"
-        response = self.client.post(self.url, data=self.data, **REQUIRED_HEADERS)
+        response = self.client.post(self.url, data=self.data)
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         print(response.context["form"].errors)
         assert bool(response.context["form"].errors) is True

--- a/brasilio_auth/tests/test_views.py
+++ b/brasilio_auth/tests/test_views.py
@@ -6,6 +6,8 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
+from traffic_control.tests.util import REQUIRED_HEADERS
+
 User = get_user_model()
 
 
@@ -23,12 +25,12 @@ class UserCreationViewTests(TestCase):
         }
 
     def test_render_correct_template(self):
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         assert "form" in response.context
 
     def test_render_form_errors_if_invalid_post(self):
-        response = self.client.post(self.url, data={})
+        response = self.client.post(self.url, data={}, **REQUIRED_HEADERS)
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         assert bool(response.context["form"].errors) is True
 
@@ -36,7 +38,7 @@ class UserCreationViewTests(TestCase):
         assert 1 == User.objects.count()  # auto import covid 19 user
         assert User.objects.filter(username=settings.COVID19_AUTO_IMPORT_USER).exists()
 
-        response = self.client.post(self.url, data=self.data)
+        response = self.client.post(self.url, data=self.data, **REQUIRED_HEADERS)
         user = User.objects.get(username="foo")
 
         self.assertRedirects(response, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False)
@@ -44,12 +46,12 @@ class UserCreationViewTests(TestCase):
         assert str(user.pk) == self.client.session["_auth_user_id"]
 
     def test_form_error_if_trying_to_create_user_with_existing_username(self):
-        response = self.client.post(self.url, data=self.data)
+        response = self.client.post(self.url, data=self.data, **REQUIRED_HEADERS)
         assert User.objects.filter(username="foo").exists()
 
         self.data["username"] = "FOO"
         self.data["email"] = "new@foo.com"
-        response = self.client.post(self.url, data=self.data)
+        response = self.client.post(self.url, data=self.data, **REQUIRED_HEADERS)
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         print(response.context["form"].errors)
         assert bool(response.context["form"].errors) is True

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -5,6 +5,7 @@ from model_bakery import baker
 
 from core.models import TableFile
 from core.tests.utils import BaseTestCaseWithSampleDataset
+from traffic_control.tests.util import REQUIRED_HEADERS
 
 
 class SampleDatasetDetailView(BaseTestCaseWithSampleDataset):
@@ -19,14 +20,14 @@ class SampleDatasetDetailView(BaseTestCaseWithSampleDataset):
         call_command("clear_cache")
 
     def test_display_dataset_table_data_with_expected_template(self):
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
         assert 200 == response.status_code
         self.assertTemplateUsed(response, "core/dataset-detail.html")
 
     @override_settings(RATELIMIT_ENABLE=True)
     @override_settings(RATELIMIT_RATE="0/s")
     def test_enforce_rate_limit_if_flagged(self):
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
         assert 429 == response.status_code
         self.assertTemplateUsed(response, "4xx.html")
         assert "Você atingiu o limite de requisições" in response.context["message"]
@@ -45,7 +46,7 @@ class TestDatasetFilesDetailView(BaseTestCaseWithSampleDataset):
         baker.make(TableFile, table=self.table)
 
     def test_render_template_with_expected_context(self):
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
 
         assert 200 == response.status_code
         self.assertTemplateUsed(response, "core/dataset_files_list.html")
@@ -57,13 +58,13 @@ class TestDatasetFilesDetailView(BaseTestCaseWithSampleDataset):
         TableFile.objects.all().delete()
 
         expected_url = self.dataset.get_last_version().download_url
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
 
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
     def test_404_if_dataset_does_not_exist(self):
         self.url = reverse("core:dataset-files-detail", args=["foo"])
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
         assert 404 == response.status_code
 
     def test_return_empty_list_if_no_visible_table(self):
@@ -71,7 +72,7 @@ class TestDatasetFilesDetailView(BaseTestCaseWithSampleDataset):
         self.table.hidden = True
         self.table.save()
 
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
 
         assert 200 == response.status_code
         self.assertTemplateUsed(response, "404.html")

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from covid19.exceptions import SpreadsheetValidationErrors
+from traffic_control.tests.util import REQUIRED_HEADERS
 
 
 class ImportSpreadsheetProxyViewTests(TestCase):
@@ -16,7 +17,7 @@ class ImportSpreadsheetProxyViewTests(TestCase):
         fake_data = {"cases": [], "reports": []}
         mock_merge.return_value = fake_data
 
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
 
         assert 200 == response.status_code
         assert fake_data == json.loads(response.content)
@@ -24,7 +25,7 @@ class ImportSpreadsheetProxyViewTests(TestCase):
 
     def test_404_if_invalid_state(self):
         self.url = reverse("covid19:spreadsheet_proxy", args=["XX"])
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
         assert 404 == response.status_code
 
     @patch("covid19.views.merge_state_data", autospec=True)
@@ -35,7 +36,7 @@ class ImportSpreadsheetProxyViewTests(TestCase):
         mock_merge.side_effect = exception
 
         self.url = reverse("covid19:spreadsheet_proxy", args=["RJ"])
-        response = self.client.get(self.url)
+        response = self.client.get(self.url, **REQUIRED_HEADERS)
 
         assert 400 == response.status_code
         assert ["error 1", "error 2"] == sorted(response.json()["errors"])

--- a/covid19/tests/test_views.py
+++ b/covid19/tests/test_views.py
@@ -5,10 +5,12 @@ from django.test import TestCase
 from django.urls import reverse
 
 from covid19.exceptions import SpreadsheetValidationErrors
-from traffic_control.tests.util import REQUIRED_HEADERS
+from traffic_control.tests.util import TrafficControlClient
 
 
 class ImportSpreadsheetProxyViewTests(TestCase):
+    client_class = TrafficControlClient
+
     def setUp(self):
         self.url = reverse("covid19:spreadsheet_proxy", args=["RJ"])
 
@@ -17,7 +19,7 @@ class ImportSpreadsheetProxyViewTests(TestCase):
         fake_data = {"cases": [], "reports": []}
         mock_merge.return_value = fake_data
 
-        response = self.client.get(self.url, **REQUIRED_HEADERS)
+        response = self.client.get(self.url)
 
         assert 200 == response.status_code
         assert fake_data == json.loads(response.content)
@@ -25,7 +27,7 @@ class ImportSpreadsheetProxyViewTests(TestCase):
 
     def test_404_if_invalid_state(self):
         self.url = reverse("covid19:spreadsheet_proxy", args=["XX"])
-        response = self.client.get(self.url, **REQUIRED_HEADERS)
+        response = self.client.get(self.url)
         assert 404 == response.status_code
 
     @patch("covid19.views.merge_state_data", autospec=True)
@@ -36,7 +38,7 @@ class ImportSpreadsheetProxyViewTests(TestCase):
         mock_merge.side_effect = exception
 
         self.url = reverse("covid19:spreadsheet_proxy", args=["RJ"])
-        response = self.client.get(self.url, **REQUIRED_HEADERS)
+        response = self.client.get(self.url)
 
         assert 400 == response.status_code
         assert ["error 1", "error 2"] == sorted(response.json()["errors"])

--- a/traffic_control/constants.py
+++ b/traffic_control/constants.py
@@ -1,0 +1,1 @@
+RATELIMITED_VIEW_ATTR = "ratelimit_enabled"

--- a/traffic_control/decorators.py
+++ b/traffic_control/decorators.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from ratelimit.decorators import ratelimit
 
+from traffic_control.constants import RATELIMITED_VIEW_ATTR
 from traffic_control.util import ratelimit_key
 
 
@@ -13,4 +14,5 @@ def enable_ratelimit(view):
             request, *args, **kwargs
         )
 
+    setattr(view_with_rate_limit, RATELIMITED_VIEW_ATTR, True)
     return view_with_rate_limit

--- a/traffic_control/tests/test_decorators.py
+++ b/traffic_control/tests/test_decorators.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory, TestCase, override_settings
 from ratelimit.exceptions import Ratelimited
 
+from traffic_control.constants import RATELIMITED_VIEW_ATTR
 from traffic_control.decorators import enable_ratelimit
 
 
@@ -18,6 +19,7 @@ class EnableRateLimitDecoratorTests(TestCase):
     @override_settings(RATELIMIT_ENABLE=False)
     @override_settings(RATELIMIT_RATE="0/s")
     def test_valid_request_if_ratelimit_is_not_enabled(self):
+        assert getattr(self.rate_limit_view, RATELIMITED_VIEW_ATTR, None) is True
         response = self.rate_limit_view(self.request, "foo_arg", "bar_arg")
         assert 200 == response.status_code
         assert "content: foo_arg and bar_arg"
@@ -25,6 +27,7 @@ class EnableRateLimitDecoratorTests(TestCase):
     @override_settings(RATELIMIT_ENABLE=True)
     @override_settings(RATELIMIT_RATE="10/s")
     def test_valid_request_if_ratelimit_enabled_but_under_threshold(self):
+        assert getattr(self.rate_limit_view, RATELIMITED_VIEW_ATTR, None) is True
         response = self.rate_limit_view(self.request, "foo_arg", "bar_arg")
         assert 200 == response.status_code
         assert "content: foo_arg and bar_arg"
@@ -32,5 +35,6 @@ class EnableRateLimitDecoratorTests(TestCase):
     @override_settings(RATELIMIT_ENABLE=True)
     @override_settings(RATELIMIT_RATE="0/s")
     def test_raise_rate_limited_exception_if_exceeding_threshold(self):
+        assert getattr(self.rate_limit_view, RATELIMITED_VIEW_ATTR, None) is True
         with pytest.raises(Ratelimited):
             self.rate_limit_view(self.request, "foo_arg", "bar_arg")

--- a/traffic_control/tests/test_decorators.py
+++ b/traffic_control/tests/test_decorators.py
@@ -1,0 +1,36 @@
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+from ratelimit.exceptions import Ratelimited
+
+from traffic_control.decorators import enable_ratelimit
+
+
+def fake_view(request, foo, bar):
+    return HttpResponse(f"content: {foo} and {bar}")
+
+
+class EnableRateLimitDecoratorTests(TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get("/")
+        self.rate_limit_view = enable_ratelimit(fake_view)
+
+    @override_settings(RATELIMIT_ENABLE=False)
+    @override_settings(RATELIMIT_RATE="0/s")
+    def test_valid_request_if_ratelimit_is_not_enabled(self):
+        response = self.rate_limit_view(self.request, "foo_arg", "bar_arg")
+        assert 200 == response.status_code
+        assert "content: foo_arg and bar_arg"
+
+    @override_settings(RATELIMIT_ENABLE=True)
+    @override_settings(RATELIMIT_RATE="10/s")
+    def test_valid_request_if_ratelimit_enabled_but_under_threshold(self):
+        response = self.rate_limit_view(self.request, "foo_arg", "bar_arg")
+        assert 200 == response.status_code
+        assert "content: foo_arg and bar_arg"
+
+    @override_settings(RATELIMIT_ENABLE=True)
+    @override_settings(RATELIMIT_RATE="0/s")
+    def test_raise_rate_limited_exception_if_exceeding_threshold(self):
+        with pytest.raises(Ratelimited):
+            self.rate_limit_view(self.request, "foo_arg", "bar_arg")

--- a/traffic_control/tests/test_middlewares.py
+++ b/traffic_control/tests/test_middlewares.py
@@ -21,3 +21,7 @@ class BlockSuspiciousRequestsMiddlewareTests(TestCase):
     def test_valid_request_if_allowed_user_agent(self):
         response = self.client.get("/", HTTP_USER_AGENT="other_agent")
         assert 429 != response.status_code
+
+    def test_middleware_pipeline_does_not_break_if_invalid_resolve(self):
+        response = self.client.get("alkjsdasd3121312", HTTP_USER_AGENT="other_agent")
+        assert 404 == response.status_code

--- a/traffic_control/tests/test_middlewares.py
+++ b/traffic_control/tests/test_middlewares.py
@@ -1,0 +1,23 @@
+from django.test import TestCase, override_settings
+
+
+class BlockSuspiciousRequestsMiddlewareTests(TestCase):
+    def assert429(self, response):
+        assert 429 == response.status_code
+        self.assertTemplateUsed(response, "4xx.html")
+        assert "Você atingiu o limite de requisições" in response.context["message"]
+        assert 429 == response.context["title_4xx"]
+
+    def test_bad_request_if_no_user_agent(self):
+        response = self.client.get("/")
+        self.assert429(response)
+
+    @override_settings(BLOCKED_WEB_AGENTS="invalid_agent")
+    def test_bad_request_if_blocked_user_agent(self):
+        response = self.client.get("/", HTTP_USER_AGENT="invalid_agent")
+        self.assert429(response)
+
+    @override_settings(BLOCKED_WEB_AGENTS="invalid_agent")
+    def test_valid_request_if_allowed_user_agent(self):
+        response = self.client.get("/", HTTP_USER_AGENT="other_agent")
+        assert 429 != response.status_code

--- a/traffic_control/tests/util.py
+++ b/traffic_control/tests/util.py
@@ -1,1 +1,8 @@
-REQUIRED_HEADERS = {"HTTP_USER_AGENT": "test-client"}
+from django.test.client import Client
+
+
+class TrafficControlClient(Client):
+    def generic(self, *args, **kwargs):
+        if "HTTP_USER_AGENT" not in kwargs:
+            kwargs["HTTP_USER_AGENT"] = "test-client"
+        return super().generic(*args, **kwargs)

--- a/traffic_control/tests/util.py
+++ b/traffic_control/tests/util.py
@@ -1,0 +1,1 @@
+REQUIRED_HEADERS = {"HTTP_USER_AGENT": "test-client"}


### PR DESCRIPTION
Fixes #436 

Esse PR aproveita também para adicionar testes unitários a nossa lógica de tratamento de rate limit no Brasil.io.