### PR TITLE
Update choices do import_data deve usar o data table corrente e não o do table do field

### DIFF
--- a/core/commands.py
+++ b/core/commands.py
@@ -59,7 +59,7 @@ class ImportDataCommand:
         try:
             with transaction.atomic():
                 if self.flag_fill_choices:
-                    self.fill_choices(Model)
+                    self.fill_choices(Model, data_table)
                 if self.flag_import_data:
                     table.data_table.deactivate(drop_table=self.flag_delete_old_table)
                     data_table.activate()
@@ -149,14 +149,14 @@ class ImportDataCommand:
         end = time.time()
         self.log("  done in {:.3f}s.".format(end - start))
 
-    def fill_choices(self, Model):
+    def fill_choices(self, Model, data_table):
         self.log("Filling choices...")
         start = time.time()
         choiceables = Field.objects.for_table(self.table).choiceables()
         for field in choiceables:
             self.log("  {}".format(field.name), end="", flush=True)
             start_field = time.time()
-            field.update_choices()
+            field.update_choices(data_table)
             field.save()
             end_field = time.time()
             self.log(" - done in {:.3f}s.".format(end_field - start_field))

--- a/core/models.py
+++ b/core/models.py
@@ -514,8 +514,8 @@ class Field(models.Model):
 
         return ", ".join(["{}={}".format(key, repr(value)) for key, value in self.options.items()])
 
-    def update_choices(self):
-        Model = self.table.get_model()
+    def update_choices(self, data_table=None):
+        Model = self.table.get_model(data_table=data_table)
         choices = Model.objects.order_by(self.name).distinct(self.name).values_list(self.name, flat=True)
         self.choices = {"data": [str(value) for value in choices]}
 


### PR DESCRIPTION
@turicas me deparei com esse seguinte erro enquanto estava fazendo o setup do brasil.io no meu PC novo seguindo as [instruções de import_data da documentação](https://github.com/turicas/brasil.io/blob/develop/docs/import-data.md#importando-os-dados):

```
$ python manage.py import_data --no-input cursos-prouni cursos ~/Downloads/cursos-prouni.csv.xz 
Importing data to new table data_cursosprouni_cursos_gcxmrigk
Importing data: 9.23Mbytes [00:00, 11.4Mbytes/s]
  done in   1.031s (41447 rows imported, 40184.759 rows/s).
Running VACUUM ANALYSE...  done in 0.340s.
Creating filter indexes...  done in 0.630s.
Filling choices...
  uf_busca/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/models/base.py:321: RuntimeWarning: Model 'core.cursosprounicursos' was already registered. Reloading models is not advised as it can lead to inconsistencies, most notably with related models.
  new_class._meta.apps.register_model(new_class._meta.app_label, new_class)
Deleting import table data_cursosprouni_cursos_gcxmrigk due to an error.
Traceback (most recent call last):
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedTable: relation "data_cursosprouni_cursos" does not exist
LINE 1: ...usca") "data_cursosprouni_cursos"."uf_busca" FROM "data_curs...
                                                             ^


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "manage.py", line 18, in <module>
    execute_from_command_line(sys.argv)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/home/bernardo/envs/brasil.io/core/management/commands/import_data.py", line 62, in handle
    collect_date=collect_date,
  File "/home/bernardo/envs/brasil.io/core/commands.py", line 69, in execute
    raise e
  File "/home/bernardo/envs/brasil.io/core/commands.py", line 62, in execute
    self.fill_choices(Model)
  File "/home/bernardo/envs/brasil.io/core/commands.py", line 159, in fill_choices
    field.update_choices()
  File "/home/bernardo/envs/brasil.io/core/models.py", line 520, in update_choices
    self.choices = {"data": [str(value) for value in choices]}
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/models/query.py", line 287, in __iter__
    self._fetch_all()
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/models/query.py", line 1303, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/models/query.py", line 180, in __iter__
    for row in compiler.results_iter(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size):
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1108, in results_iter
    results = self.execute_sql(MULTI, chunked_fetch=chunked_fetch, chunk_size=chunk_size)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/cachalot/monkey_patch.py", line 29, in inner
    return original(compiler, *args, **kwargs)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/cachalot/monkey_patch.py", line 87, in inner
    cache_key, table_cache_keys)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/cachalot/monkey_patch.py", line 52, in _get_result_or_execute_query
    result = execute_query_func()
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/cachalot/monkey_patch.py", line 68, in <lambda>
    execute_query_func = lambda: original(compiler, *args, **kwargs)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1156, in execute_sql
    cursor.execute(sql, params)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/backends/utils.py", line 98, in execute
    return super().execute(sql, params)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/cachalot/monkey_patch.py", line 125, in inner
    return original(cursor, sql, *args, **kwargs)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/sentry_sdk/integrations/django/__init__.py", line 469, in execute
    return real_execute(self, sql, params)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/bernardo/.pyenv/versions/brasil.io/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: relation "data_cursosprouni_cursos" does not exist
LINE 1: ...usca") "data_cursosprouni_cursos"."uf_busca" FROM "data_curs...
```

Não capturei esse erro quando refiz o processo no meu notebook anterior porque já possuía esse dataset importado e, por consequência, a tabela default já existia.

Para corrigir o erro, o proceso de atualização dos choices do field deve rodar em cima da data table **criada para a importação** e não na tabela já existente. Esse PR faz isso.