### PR TITLE
Marcmatias/melhora dashboard mobile

### DIFF
--- a/covid19/static/covid19/css/map.css
+++ b/covid19/static/covid19/css/map.css
@@ -34,6 +34,21 @@ nav.nav-state-selector ul {
   text-align: center;
 }
 
+#dashboard-links {
+  margin-bottom: 20px;
+  overflow: auto;
+  white-space: nowrap;
+}
+
+#dashboard-links a {
+  display: inline-block;
+  margin: 5px;
+}
+
+.chart{
+  height: 40vh; 
+  margin-bottom: 130px;
+}
 
 .info {
   padding: 6px 8px;

--- a/covid19/static/covid19/js/table.js
+++ b/covid19/static/covid19/js/table.js
@@ -3,8 +3,8 @@ var dt;
 jQuery(document).ready(function() {
   if (selectedStateId === undefined) {
     var columns = [
-      { "width": "18%" },
-      { "width": "18%" },
+      { "width": "14%" },
+      { "width": "22%" },
       { "width": "14%" },
       { "width": "10%" },
       { "width": "10%" },
@@ -15,8 +15,8 @@ jQuery(document).ready(function() {
   }
   else {
     var columns = [
-      { "width": "25%" },
-      { "width": "25%" },
+      { "width": "20%" },
+      { "width": "30%" },
       { "width": "10%" },
       { "width": "10%" },
       { "width": "10%" },
@@ -28,6 +28,7 @@ jQuery(document).ready(function() {
     "autoWidth": false,
     "columns": columns,
     "scrollY":        "600px",
+    "scrollX": true,
     "scrollCollapse": true,
     "paging":         false,
     "searching":      true,

--- a/covid19/templates/covid19/dashboard.html
+++ b/covid19/templates/covid19/dashboard.html
@@ -14,13 +14,13 @@
 <script type="text/javascript" language="javascript" src="{% static 'dashboard/js/chart.js' %}"></script>
 <script type="text/javascript" language="javascript" src="{% static 'covid19/js/base.js' %}"></script>
 <script type="text/javascript" language="javascript" src="{% static 'covid19/js/chart.js' %}"></script>
-<script type="text/javascript" language="javascript" src="{% static 'covid19/js/map.js' %}"></script>
 <script type="text/javascript" language="javascript" src="{% static 'covid19/js/table.js' %}"></script>
+<script type="text/javascript" language="javascript" src="{% static 'covid19/js/map.js' %}"></script>
 {% endblock %}
 
 {% block content %}{% localize on %}
 <div id="dashboard-header">
-  <h1> ESPECIAL COVID-19 - Dados por Município </h1>
+  <h1 class="header m-t-15 m-b-15"> ESPECIAL COVID-19 - Dados por Município </h1>
   {% include 'covid19/text.html' %}
   {% include 'covid19/links.html' %}
 </div>
@@ -64,7 +64,7 @@
   </nav>
 </div>
 
-<h2>Casos de COVID-19 {% if state %}por estado: {{ state_name }}{% else %}no Brasil{% endif %}</h2>
+<h1 class="header p-t-20 p-b-10">Casos de COVID-19 {% if state %}por estado: {{ state_name }}{% else %}no Brasil{% endif %}</h1>
 {% if state %}
 <div class="row card" style="height: 100%">
   <div class="card-content teal-text card-title">
@@ -103,7 +103,7 @@
     Nota: casos importados não estão representados no mapa.
   </div>
 
-  <div id="table-col" class="col xl12 l12 m12 s12" style="height: 850px; overflow: hidden">
+  <div id="table-col" class="col xl12 l12 m12 s12" style="margin-top:25px; height: 850px; overflow: hidden">
     <table class="table mdl-data-table">
       <thead>
         <tr>
@@ -145,35 +145,29 @@
 <div style="clear: both">
 </div>
 
-<div class="row" style="height: 415px">
-  <div class="col xl6 l6 m12 s12">
+<div class="row">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="case-daily-chart-1"></canvas>
   </div>
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="death-daily-chart-1"></canvas>
   </div>
-</div>
-<div class="row" style="height: 415px">
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="case-daily-chart-2"></canvas>
   </div>
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="death-daily-chart-2"></canvas>
   </div>
-</div>
-<div class="row" style="height: 415px">
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="death-weekly-2020-chart"></canvas>
   </div>
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="death-weekly-years-chart"></canvas>
   </div>
-</div>
-<div class="row" style="height: 415px">
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart" style="margin-bottom: 180px;">
     <canvas id="death-weekly-excess-chart-1"></canvas>
   </div>
-  <div class="col xl6 l6 m12 s12">
+  <div class="col xl6 l6 m12 s12 chart">
     <canvas id="death-weekly-excess-chart-2"></canvas>
   </div>
 </div>

--- a/covid19/templates/covid19/links.html
+++ b/covid19/templates/covid19/links.html
@@ -1,19 +1,19 @@
-  <div class="center">
-    <a class="btn"
-      href="https://blog.brasil.io/2020/03/23/dados-coronavirus-por-municipio-mais-atualizados/">
-      Sobre o projeto
-    </a>
-    <a class="btn" href="{% url 'core:dataset-detail' 'covid19' %}">
-      Dados completos
-    </a>
-    <a class="btn" href="{% url 'covid19:bulletins' %}">
-      Boletins diários
-    </a>
-    <a class="btn" href="https://github.com/turicas/covid19-br/tree/master/api.md">
-      Documentação da API
-    </a>
-    <a class="btn" href="https://github.com/turicas/covid19-br/tree/master/clipping.md">
-      Quem está usando
-    </a>
-    <a class="btn" href="{% url 'core:donate' %}">Apoie o projeto</a>
-  </div>
+<div id="dashboard-links" class="center">
+  <a class="btn"
+    href="https://blog.brasil.io/2020/03/23/dados-coronavirus-por-municipio-mais-atualizados/">
+    Sobre o projeto
+  </a>
+  <a class="btn" href="{% url 'core:dataset-detail' 'covid19' %}">
+    Dados completos
+  </a>
+  <a class="btn" href="{% url 'covid19:bulletins' %}">
+    Boletins diários
+  </a>
+  <a class="btn" href="https://github.com/turicas/covid19-br/tree/master/api.md">
+    Documentação da API
+  </a>
+  <a class="btn" href="https://github.com/turicas/covid19-br/tree/master/clipping.md">
+    Quem está usando
+  </a>
+  <a class="btn" href="{% url 'core:donate' %}">Apoie o projeto</a>
+</div>

--- a/dashboard/static/dashboard/js/chart.js
+++ b/dashboard/static/dashboard/js/chart.js
@@ -28,6 +28,7 @@ class MultiLineChart {
     this.yLabels = options.yLabels;
     this.yData = options.yData;
     this.chartOptions = {
+      maintainAspectRatio: false,
       animation: {duration: this.animationDuration},
       bezierCurve: false,
       legend: {


### PR DESCRIPTION
Adiciona modificações da PR #287 ao código mais atual do brasil.io e melhora exibição de gráficos em mobile (ficam com altura maior exibindo melhor as informações contidas).

Sobre o mapa que exibe as informações das cidades, @turicas talvez fosse melhor que não fosse exibido caso o acesso fosse mobile e aí teria um link ou botão para que o usuário pudesse visualizar isso em outra tela em modo tela cheia e com o reconhecimento adequado de toques. Inclusive foi o que vi como sugestão na documentação do [leafletj](https://leafletjs.com/examples/mobile/).