### PR TITLE
Corrige /covid19/import-data/<STATE> para usar nomes de 2020

### DIFF
--- a/core/management/commands/update_fields_from_csv.py
+++ b/core/management/commands/update_fields_from_csv.py
@@ -22,7 +22,9 @@ class Command(BaseCommand):
         )
         fieldset = set(table.field_names)
         if fieldset != expected_fieldset:
-            raise ValueError(f"Field names didn't match ({fieldset - expected_fieldset} / {expected_fieldset - fieldset})")
+            raise ValueError(
+                f"Field names didn't match ({fieldset - expected_fieldset} / {expected_fieldset - fieldset})"
+            )
 
         with transaction.atomic():
             fields_to_save, tables_created = [], []

--- a/covid19/spreadsheet.py
+++ b/covid19/spreadsheet.py
@@ -44,7 +44,11 @@ def merge_state_data(state):
 
     ordered_cases = []
     for row in final_cases:
-        ordered_cases.append(row_with_sorted_columns(row))
+        row = row_with_sorted_columns(row)
+        city_info = get_city_info(row["municipio"], state)
+        if city_info:
+            row["municipio"] = city_info.city
+        ordered_cases.append(row)
 
     original_data_errors.raise_if_errors()
     return {"reports": final_reports, "cases": ordered_cases}


### PR DESCRIPTION
Esse PR corrige o erro da rota `/covid19/import-data/<STATE>/` serializando as cidades com os nomes registrados pelo IBGE na estimativa populacional de 2019. 

Esse PR tem relação com o [PR 206 do covid19-br](https://github.com/turicas/covid19-br/pull/206).