### PR TITLE
Corrige label para valor None

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -112,6 +112,7 @@ def get_table_dynamic_form(table, cache=True):
         kwargs = {"required": False, "label": dynamic_field.title}
         field_factory = model_field.formfield
 
+        # null values are being saved as "None"
         if dynamic_field.has_choices and dynamic_field.choices:
             kwargs["choices"] = [("", "Todos")] + [
                 (c, c if c != "None" else "(vazio)") for c in dynamic_field.choices.get("data", [])

--- a/core/forms.py
+++ b/core/forms.py
@@ -113,7 +113,9 @@ def get_table_dynamic_form(table, cache=True):
         field_factory = model_field.formfield
 
         if dynamic_field.has_choices and dynamic_field.choices:
-            kwargs["choices"] = [("", "Todos")] + [(c, c) for c in dynamic_field.choices.get("data", [])]
+            kwargs["choices"] = [("", "Todos")] + [
+                (c, c if c != "None" else "(vazio)") for c in dynamic_field.choices.get("data", [])
+            ]
             field_factory = forms.ChoiceField
 
         return field_factory(**kwargs)

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -88,3 +88,22 @@ class DynamicModelFormTests(BaseTestCaseWithSampleDataset):
         assert "city" in form.fields
         assert isinstance(form.fields["uf"], type(self.get_model_field("uf").formfield()))
         assert isinstance(form.fields["city"], type(self.get_model_field("city").formfield()))
+
+    def test_none_value_should_display_vazio(self):
+        self.table.field_set.filter(name__in=["uf"]).update(frontend_filter=True)
+        uf_field = self.table.get_field("uf")
+        uf_field.has_choices = True
+        uf_field.choices = {"data": ["RJ", "SP", "MG", "None"]}
+        uf_field.save()
+        expected = [
+            ("", "Todos"),
+            ("RJ", "RJ"),
+            ("SP", "SP"),
+            ("MG", "MG"),
+            ("None", "(vazio)"),
+        ]
+
+        # valid form
+        DynamicFormClasss = get_table_dynamic_form(self.table, cache=False)
+
+        assert sorted(expected) == sorted(DynamicFormClasss().fields["uf"].choices)


### PR DESCRIPTION
Campos None agora são apresentados com o label "(vazio)".

@turicas tentei reproduzir o erro de CSS que também pertence a issue #477 mas não consegui. Acessei a tabela de [candidatos](https://brasil.io/dataset/eleicoes-brasil/candidatos/) e os espaços e inputs parecem estar corretos:

**Form vazio**
![Screenshot from 2020-10-13 14-27-27](https://user-images.githubusercontent.com/238223/95895068-71ab3800-0d60-11eb-92e8-acb81dc055ca.png)

![Screenshot from 2020-10-13 14-27-36](https://user-images.githubusercontent.com/238223/95895069-7374fb80-0d60-11eb-82b8-649fd384c90c.png)


**Form populado**
![Screenshot from 2020-10-13 14-28-26](https://user-images.githubusercontent.com/238223/95895075-753ebf00-0d60-11eb-8461-9c4f988f20d0.png)

![Screenshot from 2020-10-13 14-28-28](https://user-images.githubusercontent.com/238223/95895078-766fec00-0d60-11eb-8d9f-094332687f79.png)
