### PR TITLE
Adiciona página com documentação da API

### DIFF
--- a/api/docs/views.py
+++ b/api/docs/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import render
 
 from core.models import Dataset
@@ -6,5 +7,6 @@ from core.models import Dataset
 def dynamic_api_docs_view(request):
     context = {
         "datasets": Dataset.objects.api_visible(),
+        "api_host": settings.BRASILIO_API_HOST,
     }
     return render(request, "api/docs.html", context=context)

--- a/api/docs/views.py
+++ b/api/docs/views.py
@@ -1,0 +1,10 @@
+from django.shortcuts import render
+
+from core.models import Dataset
+
+
+def dynamic_api_docs_view(request):
+    context = {
+        "datasets": Dataset.objects.api_visible(),
+    }
+    return render(request, "api/docs.html", context=context)

--- a/api/templates/api/docs.html
+++ b/api/templates/api/docs.html
@@ -42,7 +42,7 @@
   <h3 id="datasets">Datasets</h3>
   <hr>
   <p>Exemplo de requisição para listar todos os datasets disponíveis na API do Brasil.io:</p>
-  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/datasets/'</code></p>
+  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://{{ api_host }}/v1/datasets/'</code></p>
 
   {% for dataset in datasets %}
     {% include "api/snippets/dataset_docs.html" with dataset=dataset %}

--- a/api/templates/api/docs.html
+++ b/api/templates/api/docs.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}Documentação da API{% endblock %}
+
+{% block content %}
+
+<div class="section">
+  <div class="row">
+      <div class="col s12">
+        <div class="card">
+          <div class="card-content">
+            <p class="card-title">Documentação da API</p>
+            <p>Aqui você pode encontrar a listagem de todos os datasets, tabelas e campos disponíveis na API do Brasil.io. Além disso, você também encontrará informações sobre como fazer requisições para a API respeitando a autenticação.</p>
+            <p><b>Importante:</b> Utilizar a API desnecessariamente e de maneira não otimizada onera muito nossos servidores e atrapalha a experiência de outros usuários. Por conta disso, nessa documentação vocè também encontrará os links para os arquivos de dados completos de todos os datasets.</p>
+
+            <br/>
+            <p class="card-title">Índice</p>
+            <ul>
+              <li><a href="#autenticacao">Autenticação</a></li>
+            {% for dataset in datasets %}
+              <li><a href="#{{ dataset.slug }}">{{ dataset.name }}</a></li>
+            {% endfor %}
+            </ul>
+
+            <span>Legendas</span>
+            <ul style="margin: 0">
+              <li><small><i class="fa fa-search"></i> Campos que permitem filtragem via query string na URL</small></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+  </div>
+
+  <h3 id="autenticacao">Autenticação</h3>
+  <hr>
+  <p>Para ter mais contexto sobre os porquês dessa autenticação, leia o nosso blogpost <a href="https://blog.brasil.io/2020/10/31/nossa-api-sera-obrigatoriamente-autenticada/" target="_blank">"Nossa API será obrigatoriamente autenticada"</a>.</p>
+  <p>A API do Brasil.IO implementa utilizando o <b>cabeçalho HTTP Authorizaton</b>. Ela espera que o valor desse cabeçalho seja sempre algo no formato <code>Token sua_chave_de_api_aqui</code>. Este é um exemplo de uma requisição para a raiz da API utilizando o Curl:</p>
+  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/'</code></p>
+  <p>Para criar e gerenciar suas chaves de API, autentique-se no sistema e acesse a página <a href="{% url 'brasilio_auth:list_api_tokens' %}">Chaves da API</a>.</p>
+
+  <h3>Datasets</h3>
+  <hr>
+  <p>Exemplo de requisição para listar todos os datasets disponíveis na API do Brasil.io:</p>
+  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/datasets/'</code></p>
+
+  {% for dataset in datasets %}
+    {% include "api/snippets/dataset_docs.html" with dataset=dataset %}
+  {% endfor %}
+
+  </div>
+{% endblock %}

--- a/api/templates/api/docs.html
+++ b/api/templates/api/docs.html
@@ -17,6 +17,7 @@
             <p class="card-title">Índice</p>
             <ul>
               <li><a href="#autenticacao">Autenticação</a></li>
+              <li><a href="#datasets">Datasets</a></li>
             {% for dataset in datasets %}
               <li><a href="#{{ dataset.slug }}">{{ dataset.name }}</a></li>
             {% endfor %}
@@ -38,7 +39,7 @@
   <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/'</code></p>
   <p>Para criar e gerenciar suas chaves de API, autentique-se no sistema e acesse a página <a href="{% url 'brasilio_auth:list_api_tokens' %}">Chaves da API</a>.</p>
 
-  <h3>Datasets</h3>
+  <h3 id="datasets">Datasets</h3>
   <hr>
   <p>Exemplo de requisição para listar todos os datasets disponíveis na API do Brasil.io:</p>
   <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/datasets/'</code></p>

--- a/api/templates/api/docs.html
+++ b/api/templates/api/docs.html
@@ -22,11 +22,6 @@
               <li><a href="#{{ dataset.slug }}">{{ dataset.name }}</a></li>
             {% endfor %}
             </ul>
-
-            <span>Legendas</span>
-            <ul style="margin: 0">
-              <li><small><i class="fa fa-search"></i> Campos que permitem filtragem via query string na URL</small></li>
-            </ul>
           </div>
         </div>
       </div>

--- a/api/templates/api/snippets/dataset_docs.html
+++ b/api/templates/api/snippets/dataset_docs.html
@@ -1,0 +1,24 @@
+<h4 id="{{ dataset.slug }}">{{ dataset.name }}</h4>
+<hr/>
+
+<p>Exemplo de requisição para apresentar informações sobre esse dataset:</p>
+<p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/dataset/{{ dataset.slug }}/'</code></p>
+<p>O <b>dataset completo</b> pode ser baixado diretamente <a href="{{ dataset.files_url }}">nesta página</a>. Por favor, dê preferência a baixar o dataset completo caso você vá precisar de todos aos dados ao invés de utilizar a API.</p>
+
+{% for table in dataset.tables %}
+  {% if table.api_enabled %}
+  <h5 id="{{ dataset.slug }}-{{ dataset.table }}">Tabela {{ table.name }}</h5>
+  <p>Exemplo de requisição para os dados desta tabela:</p>
+  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/dataset/{{ dataset.slug }}/{{ table.name }}/data/'</code></p>
+  <h6>Colunas</h6>
+
+  <ul class="table-fields">
+    {% for field in table.fields %}
+      {% if field.show %}
+        <li>{% if field.frontend_filter %}<i title="Pode ser utilizado como filtro via query string" class="fa fa-search"></i> {% endif %}<code>{{ field.name }}</code> ({{ field.title }}){% if field.description %}: {{ field.description }}{% endif %}</li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+{% endfor %}

--- a/api/templates/api/snippets/dataset_docs.html
+++ b/api/templates/api/snippets/dataset_docs.html
@@ -15,7 +15,7 @@
   <ul class="table-fields">
     {% for field in table.fields %}
       {% if field.show %}
-        <li>{% if field.frontend_filter %}<i title="Pode ser utilizado como filtro via query string" class="fa fa-search"></i> {% endif %}<code>{{ field.name }}</code> ({{ field.title }}){% if field.description %}: {{ field.description }}{% endif %}</li>
+        <li><code>{{ field.name }}</code> ({{ field.get_type_display }}): {{ field.title }} </li>
       {% endif %}
     {% endfor %}
   </ul>

--- a/api/templates/api/snippets/dataset_docs.html
+++ b/api/templates/api/snippets/dataset_docs.html
@@ -14,9 +14,22 @@
 
   <ul class="table-fields">
     {% for field in table.fields %}
-      {% if field.show %}
-        <li><code>{{ field.name }}</code> ({{ field.get_type_display }}): {{ field.title }} </li>
-      {% endif %}
+        <li><code>{{ field.name }}</code> ({{ field.get_type_display }})
+
+        {% if field.show %}
+          {% if field.show_on_frontend %}<i class="fa fa-eye" title="Esse campo é visível na interface Web, na API e no download completo"></i>{% endif %}
+          {% if not field.show_on_frontend %}<i class="fa fa-low-vision" title="Esse campo não é visível na interface Web, apenas na API e no download completo"></i>{% endif %}
+        {% else %}
+          {% if not field.show_on_frontend %}<i class="fa fa-eye-slash" title="Esse campo é usado internamente e fica visível apenas no download completo"></i>{% endif %}
+        {% endif %}
+
+        {% if field.frontend_filter %}<i class="fa fa-filter" title="Você pode fazer filtros por esse campo na interface Web e na API"></i>{% endif %}
+
+        {% if field.searchable %}<i class="fa fa-search" title="Você pode utilizar a busca de texto completo nesse campo"></i>{% endif %}
+
+        {% if field.has_choices %}<i class="fa fa-list-ul" title="Esse campo possui valores categóricos"></i>{% endif %}
+
+        : {{ field.title }} </li>
     {% endfor %}
   </ul>
   {% endif %}

--- a/api/templates/api/snippets/dataset_docs.html
+++ b/api/templates/api/snippets/dataset_docs.html
@@ -2,14 +2,14 @@
 <hr/>
 
 <p>Exemplo de requisição para apresentar informações sobre esse dataset:</p>
-<p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/dataset/{{ dataset.slug }}/'</code></p>
+<p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://{{ api_host }}/v1/dataset/{{ dataset.slug }}/'</code></p>
 <p>O <b>dataset completo</b> pode ser baixado diretamente <a href="{{ dataset.files_url }}">nesta página</a>. Por favor, dê preferência a baixar o dataset completo caso você vá precisar de todos aos dados ao invés de utilizar a API.</p>
 
 {% for table in dataset.tables %}
   {% if table.api_enabled %}
   <h5 id="{{ dataset.slug }}-{{ dataset.table }}">Tabela {{ table.name }}</h5>
   <p>Exemplo de requisição para os dados desta tabela:</p>
-  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://api.brasil.io/v1/dataset/{{ dataset.slug }}/{{ table.name }}/data/'</code></p>
+  <p><code>curl -X GET -k -H 'Authorization: Token 123412341234' -i 'https://{{ api_host }}/v1/dataset/{{ dataset.slug }}/{{ table.name }}/data/'</code></p>
   <h6>Colunas</h6>
 
   <ul class="table-fields">

--- a/brasilio/urls.py
+++ b/brasilio/urls.py
@@ -7,8 +7,8 @@ from api.docs.views import dynamic_api_docs_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/docs/", dynamic_api_docs_view, name="api_docs"),
     path("api/", include("brasilio.api_urls")),
-    path("documentacao-api/", dynamic_api_docs_view, name="api_docs"),
     path("auth/", include("brasilio_auth.urls", namespace="brasilio_auth")),
     path("covid19/", include("covid19.urls", namespace="covid19")),
     path("django-rq/", include("django_rq.urls")),

--- a/brasilio/urls.py
+++ b/brasilio/urls.py
@@ -3,9 +3,12 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
+from api.docs.views import dynamic_api_docs_view
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("brasilio.api_urls")),
+    path("documentacao-api/", dynamic_api_docs_view, name="api_docs"),
     path("auth/", include("brasilio_auth.urls", namespace="brasilio_auth")),
     path("covid19/", include("covid19.urls", namespace="covid19")),
     path("django-rq/", include("django_rq.urls")),

--- a/core/templates/core/menu.html
+++ b/core/templates/core/menu.html
@@ -32,6 +32,7 @@
   <li><a href="{% url 'core:dataset-list' %}">Datasets</a></li>
   <li><a href="{% url 'core:specials' %}">Páginas Especiais</a></li>
   <li><a href="{% url 'v1:api-root' %}">API</a></li>
+  <li><a href="{% url 'api_docs' %}">API Docs</a></li>
 </ul>
 
 <li><a class="dropdown-trigger" href="#!" data-target="{{id_prefix}}-about-dropdown">


### PR DESCRIPTION
Fixes #204

Finalmente parei para implementar a documentação dinâmica da API do Brasil.io. Seguem uns prints de como está a carinha dela agora:

![Screenshot from 2020-11-11 16-36-25](https://user-images.githubusercontent.com/238223/98856352-2dcd5080-243c-11eb-80ca-211bbaf324d9.png)


![Screenshot from 2020-11-11 16-36-36](https://user-images.githubusercontent.com/238223/98856356-2efe7d80-243c-11eb-95a9-07a1c584f83a.png)
