### PR TITLE
Fix/auth backend

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -28,22 +28,18 @@ jobs:
         ENV_FILE: .env
         PROJECT_NAME: brasil.io
         DOCKER_COMPOSE_FILE: docker-compose.yml
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -I -r requirements-development.txt
     - name: Migrate and Update Data
       run: |
-        python manage.py migrate --no-input
+        docker-compose run web python manage.py migrate --no-input
     - name: Collect static staticfiles
       run: |
-        python manage.py collectstatic --no-input
+        docker-compose run web python manage.py collectstatic --no-input
     - name: Run Tests
       run: |
-        pytest
+        docker-compose run web pytest
     - name: Run black
       run: |
-        black . --exclude "docker" -l 120 --check
+        docker-compose run web black . --exclude "docker" -l 120 --check
     - name: Run flake8
       run: |
-        flake8 --config setup.cfg
+        docker-compose run web flake8 --config setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ lint:
 	autoflake --in-place --recursive --remove-unused-variables --remove-all-unused-imports .
 	isort --skip migrations --skip brasilio/wsgi.py -rc .
 	black . --exclude "docker" -l 120
-	flake8
+	flake8 --ignore=E203,E231
 
 test:
 	pytest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ lint:
 	autoflake --in-place --recursive --remove-unused-variables --remove-all-unused-imports .
 	isort --skip migrations --skip brasilio/wsgi.py -rc .
 	black . --exclude "docker" -l 120
-	flake8 --ignore=E203,E231
+	flake8 --config setup.cfg
 
 test:
 	pytest

--- a/api/admin.py
+++ b/api/admin.py
@@ -3,8 +3,6 @@ from django.contrib.auth import get_user_model
 
 from api.models import Token
 
-User = get_user_model()
-
 
 class TokenAdmin(admin.ModelAdmin):
     list_display = ("key", "user", "created")

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.contrib.auth import get_user_model
 
 from api.models import Token
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -174,11 +174,7 @@ class TestAPIRedirectsFromPreviousRoutingToVersioned(TestCase):
         ]
 
         for url, redirect_url in path_assertions:
-            response = self.client.get(
-                url,
-                HTTP_HOST=settings.BRASILIO_API_HOST,
-                **auth_header,
-            )
+            response = self.client.get(url, HTTP_HOST=settings.BRASILIO_API_HOST, **auth_header,)
             self.assertRedirects(response, redirect_url, msg_prefix=url, fetch_redirect_response=False, status_code=301)
 
         assert "/datasets/" == path_assertions[0][0]

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -153,7 +153,11 @@ class TestAPIRedirectsFromPreviousRoutingToVersioned(TestCase):
         assert "/api/v1/datasets/" == path_assertions[0][1]
 
     def test_redirects_from_api_host(self):
-        self.client.force_login(baker.make(User))
+        settings.ALLOWED_HOSTS.append(settings.BRASILIO_API_HOST)
+        user = baker.make(User, is_active=True)
+        self.client.force_login(user)
+        token = baker.make("api.Token", user=user)
+        auth_header = {"HTTP_AUTHORIZATION": f"Token {token.key}"}
 
         urlconf = settings.API_ROOT_URLCONF
         path_assertions = [
@@ -170,7 +174,11 @@ class TestAPIRedirectsFromPreviousRoutingToVersioned(TestCase):
         ]
 
         for url, redirect_url in path_assertions:
-            response = self.client.get(url, HTTP_HOST=settings.BRASILIO_API_HOST)
+            response = self.client.get(
+                url,
+                HTTP_HOST=settings.BRASILIO_API_HOST,
+                **auth_header,
+            )
             self.assertRedirects(response, redirect_url, msg_prefix=url, fetch_redirect_response=False, status_code=301)
 
         assert "/datasets/" == path_assertions[0][0]

--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 import environ
 import sentry_sdk
 from django.urls import reverse_lazy

--- a/brasilio_auth/auth_backend.py
+++ b/brasilio_auth/auth_backend.py
@@ -11,9 +11,9 @@ class UsernameOrEmailBackend(ModelBackend):
             return None
         elif "@" in username:
             # Won't allow anybody having "@" in username to log in
-            query = Q(email=username)
+            query = Q(email=username) # TODO: use lower of both
         else:
-            query = Q(username=username)
+            query = Q(username=username)  # TODO: use lower of both
 
         try:
             user = User.objects.get(query)

--- a/brasilio_auth/auth_backend.py
+++ b/brasilio_auth/auth_backend.py
@@ -10,10 +10,9 @@ class UsernameOrEmailBackend(ModelBackend):
         if username is None:
             return None
         elif "@" in username:
-            # Won't allow anybody having "@" in username to log in
-            query = Q(email=username) # TODO: use lower of both
+            query = Q(email__iexact=username.strip())
         else:
-            query = Q(username=username)  # TODO: use lower of both
+            query = Q(username__iexact=username.strip())
 
         try:
             user = User.objects.get(query)

--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -9,6 +9,15 @@ from utils.forms import FlagedReCaptchaField as ReCaptchaField
 
 
 USERNAME_REGEXP = re.compile(r"[^A-Za-z0-9_]")
+PUNCT_REGEXP = re.compile("[-/ .]")
+
+
+def is_valid_username(username):
+    return not (
+        PUNCT_REGEXP.sub("", username).isdigit()
+        or
+        USERNAME_REGEXP.search(username)
+    )
 
 
 class UserCreationForm(RegistrationFormUniqueEmail):
@@ -28,11 +37,10 @@ class UserCreationForm(RegistrationFormUniqueEmail):
         fields = ("username", "email")
 
     def clean_username(self):
-        username = self.cleaned_data.get("username", "")
-        non_valid_chars = USERNAME_REGEXP.search(username)
-        if non_valid_chars:
+        username = self.cleaned_data.get("username", "").strip()
+        if not is_valid_username(username):
             raise forms.ValidationError(
-                "Nome de usário somente pode conter letras, números e '_'"
+                "Nome de usuário pode conter apenas letras, números e '_' e não deve ser um documento"
             )
         return username
 

--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -10,6 +10,7 @@ from utils.forms import FlagedReCaptchaField as ReCaptchaField
 
 USERNAME_REGEXP = re.compile(r"[^A-Za-z0-9_]")
 PUNCT_REGEXP = re.compile("[-/ .]")
+User = get_user_model()
 
 
 def is_valid_username(username):
@@ -42,13 +43,14 @@ class UserCreationForm(RegistrationFormUniqueEmail):
             raise forms.ValidationError(
                 "Nome de usuário pode conter apenas letras, números e '_' e não deve ser um documento"
             )
+        elif username and User.objects.filter(username__iexact=username).exists():
+            raise forms.ValidationError(f"Nome de usuário já existente (escolha um diferente).")
         return username
 
     def clean_email(self):
         email = self.cleaned_data.get("email")
-        if email:
-            if get_user_model().objects.filter(email__iexact=email).exists():
-                raise forms.ValidationError(f"Usuário com o email {email} já cadastrado.")
+        if email and User.objects.filter(email__iexact=email).exists():
+            raise forms.ValidationError(f"Usuário com o email {email} já cadastrado.")
         return email
 
 

--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -1,3 +1,5 @@
+import re
+
 from django import forms
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
@@ -24,7 +26,13 @@ class UserCreationForm(RegistrationFormUniqueEmail):
 
     def clean_username(self):
         username = self.cleaned_data.get("username", "")
-        return username.lower()
+        username = username.lower()
+        non_valid_chars = re.search(r"[^a-z0-9_]", username)
+        if non_valid_chars:
+            raise forms.ValidationError(
+                "Nome de usário somente pode conter letras, números e '_'"
+            )
+        return username
 
     def clean_email(self):
         email = self.cleaned_data.get("email")

--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -8,6 +8,9 @@ from django_registration.forms import RegistrationFormUniqueEmail
 from utils.forms import FlagedReCaptchaField as ReCaptchaField
 
 
+USERNAME_REGEXP = re.compile(r"[^a-z0-9_]")
+
+
 class UserCreationForm(RegistrationFormUniqueEmail):
     username = forms.CharField(widget=forms.TextInput(attrs={"style": "text-transform: lowercase"}),)
     email = forms.EmailField()
@@ -27,7 +30,7 @@ class UserCreationForm(RegistrationFormUniqueEmail):
     def clean_username(self):
         username = self.cleaned_data.get("username", "")
         username = username.lower()
-        non_valid_chars = re.search(r"[^a-z0-9_]", username)
+        non_valid_chars = USERNAME_REGEXP.search(username)
         if non_valid_chars:
             raise forms.ValidationError(
                 "Nome de usário somente pode conter letras, números e '_'"

--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -8,7 +8,7 @@ from django_registration.forms import RegistrationFormUniqueEmail
 from utils.forms import FlagedReCaptchaField as ReCaptchaField
 
 
-USERNAME_REGEXP = re.compile(r"[^a-z0-9_]")
+USERNAME_REGEXP = re.compile(r"[^A-Za-z0-9_]")
 
 
 class UserCreationForm(RegistrationFormUniqueEmail):
@@ -29,7 +29,6 @@ class UserCreationForm(RegistrationFormUniqueEmail):
 
     def clean_username(self):
         username = self.cleaned_data.get("username", "")
-        username = username.lower()
         non_valid_chars = USERNAME_REGEXP.search(username)
         if non_valid_chars:
             raise forms.ValidationError(

--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -7,18 +7,13 @@ from django_registration.forms import RegistrationFormUniqueEmail
 
 from utils.forms import FlagedReCaptchaField as ReCaptchaField
 
-
 USERNAME_REGEXP = re.compile(r"[^A-Za-z0-9_]")
 PUNCT_REGEXP = re.compile("[-/ .]")
 User = get_user_model()
 
 
 def is_valid_username(username):
-    return not (
-        PUNCT_REGEXP.sub("", username).isdigit()
-        or
-        USERNAME_REGEXP.search(username)
-    )
+    return not (PUNCT_REGEXP.sub("", username).isdigit() or USERNAME_REGEXP.search(username))
 
 
 class UserCreationForm(RegistrationFormUniqueEmail):
@@ -44,7 +39,7 @@ class UserCreationForm(RegistrationFormUniqueEmail):
                 "Nome de usuário pode conter apenas letras, números e '_' e não deve ser um documento"
             )
         elif username and User.objects.filter(username__iexact=username).exists():
-            raise forms.ValidationError(f"Nome de usuário já existente (escolha um diferente).")
+            raise forms.ValidationError("Nome de usuário já existente (escolha um diferente).")
         return username
 
     def clean_email(self):

--- a/brasilio_auth/scripts/migrate_wrong_usernames.py
+++ b/brasilio_auth/scripts/migrate_wrong_usernames.py
@@ -51,9 +51,8 @@ def migrate_usernames(filepath):
         writer.writeheader()
         for user in User.objects.filter(username__contains="@"):
             possible = possible_usernames(user.username, user.email)
-            changed = False
             for username in possible:
-                if not User.objects.filter(username=username).exists() and not changed:
+                if not User.objects.filter(username=username).exists():
                     writer.writerow(
                         {
                             "old_username": user.username,
@@ -61,9 +60,9 @@ def migrate_usernames(filepath):
                             "email": user.email
                         }
                     )
-                    changed = True
                     user.username = username
                     user.save()
+                    break
 
 
 def run():

--- a/brasilio_auth/scripts/migrate_wrong_usernames.py
+++ b/brasilio_auth/scripts/migrate_wrong_usernames.py
@@ -43,8 +43,7 @@ def possible_usernames(username:str, email:str, n_suffix:int = 10) -> Tuple[str,
     return (username, possible_2, possible_3, *possible_with_suffix)
 
 
-def migrate_usernames(filepath=None):
-    filepath = filepath or "/data/fixed-usernames.csv"
+def migrate_usernames(filepath):
     with open(filepath, mode="w") as fobj:
         writer = csv.DictWriter(
             fobj, fieldnames=["old_username", "new_username", "email"]
@@ -65,3 +64,8 @@ def migrate_usernames(filepath=None):
                     changed = True
                     user.username = username
                     user.save()
+
+
+def run():
+    filepath = "/data/fixed-usernames.csv"
+    migrate_usernames(filepath)

--- a/brasilio_auth/scripts/migrate_wrong_usernames.py
+++ b/brasilio_auth/scripts/migrate_wrong_usernames.py
@@ -15,7 +15,7 @@ from typing import Tuple
 from django.contrib.auth import get_user_model
 from rows.utils import slug
 
-from brasilio_auth.forms import UserCreationForm
+from brasilio_auth.forms import is_valid_username
 
 User = get_user_model()
 possible_chars = string.ascii_letters + string.digits + "_"
@@ -54,8 +54,7 @@ def migrate_usernames(filepath):
         )
         writer.writeheader()
         for user in User.objects.all():
-            if user.username.lower() == slug(user.username, permitted_chars=possible_chars):
-                # Valid username
+            if is_valid_username(user.username):
                 continue
 
             # Define possible usernames based on current and remove any

--- a/brasilio_auth/scripts/migrate_wrong_usernames.py
+++ b/brasilio_auth/scripts/migrate_wrong_usernames.py
@@ -21,7 +21,7 @@ User = get_user_model()
 possible_chars = string.ascii_letters + string.digits + "_"
 
 
-def possible_usernames(username:str, email:str, n_suffix:int = 10) -> Tuple[str, ...]:
+def possible_usernames(username: str, email: str, n_suffix: int = 10) -> Tuple[str, ...]:
     username = username.strip()
     email = email.strip()
 
@@ -34,7 +34,7 @@ def possible_usernames(username:str, email:str, n_suffix:int = 10) -> Tuple[str,
             username = username[:-1]
         if "@" in username:
             stop = username.find("@")
-            before, after = username[:stop], username[stop + 1:]
+            before, after = username[:stop], username[stop + 1 :]
             if "." in after:
                 username = before
             else:
@@ -49,9 +49,7 @@ def possible_usernames(username:str, email:str, n_suffix:int = 10) -> Tuple[str,
 
 def migrate_usernames(filepath):
     with open(filepath, mode="w") as fobj:
-        writer = csv.DictWriter(
-            fobj, fieldnames=["old_username", "new_username", "email"]
-        )
+        writer = csv.DictWriter(fobj, fieldnames=["old_username", "new_username", "email"])
         writer.writeheader()
         for user in User.objects.all():
             if is_valid_username(user.username):
@@ -65,13 +63,7 @@ def migrate_usernames(filepath):
             ]
             for username in possible:
                 if not User.objects.filter(username=username).exists():
-                    writer.writerow(
-                        {
-                            "old_username": user.username,
-                            "new_username": username,
-                            "email": user.email
-                        }
-                    )
+                    writer.writerow({"old_username": user.username, "new_username": username, "email": user.email})
                     user.username = username
                     user.save()
                     break

--- a/brasilio_auth/scripts/migrate_wrong_usernames.py
+++ b/brasilio_auth/scripts/migrate_wrong_usernames.py
@@ -1,0 +1,60 @@
+"""
+TODO: relatar problema da issue de login
+"""
+
+def possible_usernames(username, email):
+    """
+    >>> possible_usernames('test@example.com', 'test@example.com')
+    ('test', 'test', 'test_example')
+    >>> possible_usernames('@test', 'test@example.com')
+    ('test', 'test', 'test_example')
+    >>> possible_usernames('test@', 'test@example.com')
+    ('test', 'test', 'test_example')
+    >>> possible_usernames('@test@', 'test@example.com')
+    ('test', 'test', 'test_example')
+    >>> possible_usernames('test@123', 'test@example.com')
+    ('test_123', 'test', 'test_example')
+    >>> possible_usernames('test@exampl.com', 'test@example.com')
+    ('test', 'test', 'test_example')
+    """
+    username = username.strip()
+    email = email.strip()
+
+    if username.lower() == email.lower():
+        username = username.split("@")[0]
+    else:
+        if username.startswith("@"):
+            username = username[1:]
+        if username.endswith("@"):
+            username = username[:-1]
+        if "@" in username:
+            stop = username.find("@")
+            before, after = username[:stop], username[stop + 1:]
+            if "." in after:
+                username = before
+            else:
+                username = "_".join(username.split("@"))
+
+    email_parts = email.split("@")
+    possible_2 = email_parts[0]
+    possible_3 = email_parts[0] + "_" + email_parts[1].split(".")[0]
+    return (username, possible_2, possible_3)
+
+
+def migrate_usernames():
+    # with open("/data/fixed-usernames.csv", mode="w") as fobj:
+    # writer = csv.DictWriter(fobj, fieldnames=["old_username", "new_username", "email"])
+    for user in User.objects.filter(username__contains="@"):
+        possible = possible_usernames(user.username, user.email)
+        changed = False
+        for username in possible:
+            if not User.objects.filter(username=username).exists():
+                # writer.writerow(...)
+                changed = True
+                # TODO: save user.email in CSV
+                # TODO: create script to send email
+                #user.username = new
+                #user.save()
+                pass
+        if not changed:
+            print(f"Conflict in: {user.username} / {user.email} (would be: {new} but already exists)")

--- a/brasilio_auth/templates/brasilio_auth/login.html
+++ b/brasilio_auth/templates/brasilio_auth/login.html
@@ -9,14 +9,14 @@
       {% if form.errors %}
           {% for field in form %}
               {% for error in field.errors %}
-                 <p class="red-text text-lighten-3">
+                  <p class="red-text text-lighten-3">
                       {{ error|escape }}
                   </p>
               {% endfor %}
           {% endfor %}
           {% for error in form.non_field_errors %}
-             <p class="red-text text-lighten-3">
-                 {{ error|escape }}
+              <p class="red-text text-lighten-3">
+                  {{ error|escape }}
               </p>
           {% endfor %}
       {% endif %}

--- a/brasilio_auth/templates/brasilio_auth/login.html
+++ b/brasilio_auth/templates/brasilio_auth/login.html
@@ -7,9 +7,18 @@
       <h4>Login</h4>
 
       {% if form.errors %}
-        <p class="red-text text-lighten-3">
-          Senha inválida. Por favor tente novamente.
-        </p>
+          {% for field in form %}
+              {% for error in field.errors %}
+                 <p class="red-text text-lighten-3">
+                      {{ error|escape }}
+                  </p>
+              {% endfor %}
+          {% endfor %}
+          {% for error in form.non_field_errors %}
+             <p class="red-text text-lighten-3">
+                 {{ error|escape }}
+              </p>
+          {% endfor %}
       {% endif %}
 
       {% if next %}

--- a/brasilio_auth/tests/test_forms.py
+++ b/brasilio_auth/tests/test_forms.py
@@ -11,6 +11,10 @@ from brasilio_auth.models import NewsletterSubscriber
 
 
 class UserCreationFormTests(TestCase):
+    username_invalid_error = "Nome de usuário pode conter apenas letras, números e '_' e não deve ser um documento"
+    username_max_length_error = "Certifique-se de que o valor tenha no máximo 150 caracteres (ele possui 151)."
+    username_exists_error = "Um usuário com este nome de usuário já existe."
+
     def test_required_fields(self):
         required_fields = ["username", "email", "password1", "password2", "captcha"]
 
@@ -60,6 +64,7 @@ class UserCreationFormTests(TestCase):
         form = UserCreationForm(data)
         assert not form.is_valid()
         assert "username" in form.errors
+        assert form.errors["username"] == [self.username_max_length_error]
 
     @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
     def test_invalid_username_if_already_exists(self):
@@ -76,6 +81,7 @@ class UserCreationFormTests(TestCase):
         form = UserCreationForm(data)
         assert form.is_valid() is False
         assert "username" in form.errors
+        assert form.errors["username"] == [self.username_exists_error]
 
     @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
     def test_invalid_email_if_user_already_exists(self):
@@ -138,6 +144,23 @@ class UserCreationFormTests(TestCase):
         form = UserCreationForm(data)
         assert not form.is_valid()
         assert "username" in form.errors
+        assert form.errors["username"] == [self.username_invalid_error]
+
+    @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
+    def test_invalid_username_digits(self):
+        passwd = "verygoodpassword"
+        data = {
+            "username": "123.456.789-01",
+            "email": "foo@bar.com",
+            "password1": passwd,
+            "password2": passwd,
+            "captcha": "captcha-validation",
+        }
+
+        form = UserCreationForm(data)
+        assert not form.is_valid()
+        assert "username" in form.errors
+        assert form.errors["username"] == [self.username_invalid_error]
 
     @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
     def test_do_not_set_username_to_lowercase(self):

--- a/brasilio_auth/tests/test_forms.py
+++ b/brasilio_auth/tests/test_forms.py
@@ -142,6 +142,21 @@ class UserCreationFormTests(TestCase):
         assert not form.is_valid()
         assert "captcha" in form.errors
 
+    @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
+    def test_invalid_username_characters(self):
+        passwd = "verygoodpassword"
+        data = {
+            "username": "foo@",
+            "email": "foo@bar.com",
+            "password1": passwd,
+            "password2": passwd,
+            "captcha": "captcha-validation",
+        }
+
+        form = UserCreationForm(data)
+        assert not form.is_valid()
+        assert "username" in form.errors
+
 
 class TestTokenApiManagementForm(TestCase):
     def test_required_fields(self):

--- a/brasilio_auth/tests/test_forms.py
+++ b/brasilio_auth/tests/test_forms.py
@@ -43,24 +43,6 @@ class UserCreationFormTests(TestCase):
         assert not NewsletterSubscriber.objects.filter(user=user).exists()
 
     @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
-    def test_force_lower_for_username(self):
-        passwd = "verygoodpassword"
-        data = {
-            "username": "FOO",
-            "email": "foo@bar.com",
-            "password1": passwd,
-            "password2": passwd,
-            "captcha": "captcha-validation",
-        }
-
-        form = UserCreationForm(data)
-        assert form.is_valid() is True
-        user = form.save()
-        user.refresh_from_db()
-
-        assert "foo" == user.username
-
-    @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
     def test_respect_abstract_user_max_length_for_username(self):
         passwd = "verygoodpassword"
         data = {
@@ -156,6 +138,22 @@ class UserCreationFormTests(TestCase):
         form = UserCreationForm(data)
         assert not form.is_valid()
         assert "username" in form.errors
+
+    @patch.object(ReCaptchaField, "validate", Mock(return_value=True))
+    def test_do_not_set_username_to_lowercase(self):
+        passwd = "verygoodpassword"
+        username = "Foo"
+        data = {
+            "username": username,
+            "email": "foo@bar.com",
+            "password1": passwd,
+            "password2": passwd,
+            "captcha": "captcha-validation",
+        }
+
+        form = UserCreationForm(data)
+        assert form.is_valid()
+        assert form.cleaned_data["username"] == username
 
 
 class TestTokenApiManagementForm(TestCase):

--- a/brasilio_auth/tests/test_scripts.py
+++ b/brasilio_auth/tests/test_scripts.py
@@ -1,0 +1,124 @@
+from tempfile import NamedTemporaryFile
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from model_bakery import baker
+from brasilio_auth.scripts.migrate_wrong_usernames import (
+    possible_usernames,
+    migrate_usernames,
+)
+
+
+User = get_user_model()
+
+
+class TestPossibleUsernames(TestCase):
+    def test_username_equal_to_email(self):
+        username = "test@example.com"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=2)
+        expected = ("test", "test", "test_example", "test_1")
+
+        assert possible_values == expected
+
+    def test_username_with_invalid_char_at_the_beginning(self):
+        username = "@test"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=2)
+        expected = ("test", "test", "test_example", "test_1")
+
+        assert possible_values == expected
+
+    def test_username_with_invalid_char_at_the_end(self):
+        username = "test@"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=2)
+        expected = ("test", "test", "test_example", "test_1")
+
+        assert possible_values == expected
+
+    def test_username_with_invalid_char_at_the_both_ends(self):
+        username = "@test@"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=2)
+        expected = ("test", "test", "test_example", "test_1")
+
+        assert possible_values == expected
+
+    def test_replace_invalid_char_with_undescore(self):
+        username = "test@123"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=2)
+        expected = ("test_123", "test", "test_example", "test_123_1")
+
+        assert possible_values == expected
+
+    def test_combine_email_with_domain_name(self):
+        username = "test@exampl.com"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=2)
+        expected = ("test", "test", "test_example", "test_1")
+
+        assert possible_values == expected
+
+    def test_create_more_possibilities_with_suffixes(self):
+        username = "test@exampl.com"
+        email = "test@example.com"
+
+        possible_values = possible_usernames(username, email, n_suffix=3)
+        expected = ("test", "test", "test_example", "test_1", "test_2")
+
+        assert possible_values == expected
+
+
+class TestReplaceUsernameWithSuggestions(TestCase):
+    def setUp(self):
+        self.user_1 = baker.make(
+            User,
+            username="test@",
+            email="test@example.com",
+        )
+        self.expected_username_1 = "test"
+
+        self.user_2 = baker.make(
+            User,
+            username="@test@",
+            email="name@example.com"
+        )
+        #  teste would already exists because of self.username_1
+        self.expected_username_2 = "name"
+
+        self.temp_file = NamedTemporaryFile(mode="r")
+        self.expected_csv = (
+            "old_username,new_username,email\n"
+            "test@,test,test@example.com\n"
+            "@test@,name,name@example.com\n"
+        )
+
+    def test_happy_path_wrong_usernames_replacement(self):
+        migrate_usernames(filepath=self.temp_file.name)
+
+        self.user_1.refresh_from_db()
+        self.user_2.refresh_from_db()
+        self.temp_file.seek(0)
+
+        assert self.user_1.username == self.expected_username_1
+        assert self.user_2.username == self.expected_username_2
+        assert self.temp_file.read() == self.expected_csv
+
+    def test_all_combinations_of_user_1_already_exists(self):
+        baker.make(User, username="test")
+        baker.make(User, username="test_example")
+
+        migrate_usernames(self.temp_file.name)
+        self.expected_username_1 = "test_1"
+
+        self.user_1.refresh_from_db()
+
+        assert self.user_1.username == self.expected_username_1

--- a/brasilio_auth/tests/test_scripts.py
+++ b/brasilio_auth/tests/test_scripts.py
@@ -3,11 +3,8 @@ from tempfile import NamedTemporaryFile
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from model_bakery import baker
-from brasilio_auth.scripts.migrate_wrong_usernames import (
-    possible_usernames,
-    migrate_usernames,
-)
 
+from brasilio_auth.scripts.migrate_wrong_usernames import migrate_usernames, possible_usernames
 
 User = get_user_model()
 
@@ -79,26 +76,16 @@ class TestPossibleUsernames(TestCase):
 
 class TestReplaceUsernameWithSuggestions(TestCase):
     def setUp(self):
-        self.user_1 = baker.make(
-            User,
-            username="test@",
-            email="test@example.com",
-        )
+        self.user_1 = baker.make(User, username="test@", email="test@example.com",)
         self.expected_username_1 = "test"
 
-        self.user_2 = baker.make(
-            User,
-            username="@test@",
-            email="name@example.com"
-        )
+        self.user_2 = baker.make(User, username="@test@", email="name@example.com")
         #  teste would already exists because of self.username_1
         self.expected_username_2 = "name"
 
         self.temp_file = NamedTemporaryFile(mode="r")
         self.expected_csv = (
-            "old_username,new_username,email\n"
-            "test@,test,test@example.com\n"
-            "@test@,name,name@example.com\n"
+            "old_username,new_username,email\n" "test@,test,test@example.com\n" "@test@,name,name@example.com\n"
         )
 
     def test_happy_path_wrong_usernames_replacement(self):

--- a/brasilio_auth/tests/test_views.py
+++ b/brasilio_auth/tests/test_views.py
@@ -76,11 +76,26 @@ class UserCreationViewTests(DjangoAssertionsMixin, TestCase):
         response = self.client.post(self.url, data=self.data)
         assert User.objects.filter(username="foo").exists()
 
-        self.data["username"] = "FOO"
+        new_username = "foo"
+        assert new_username == self.data["username"]  # same capitalization
+        self.data["username"] = new_username
         self.data["email"] = "new@foo.com"
         response = self.client.post(self.url, data=self.data)
         self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
-        print(response.context["form"].errors)
+        assert bool(response.context["form"].errors) is True
+
+    def test_form_error_if_trying_to_create_user_with_existing_username_uppercase(self):
+        response = self.client.post(self.url, data=self.data)
+        assert User.objects.filter(username="foo").exists()
+
+        new_username = "FOO"
+        # same username, different capitalization
+        assert new_username.lower() == self.data["username"].lower()
+        assert new_username != self.data["username"]
+        self.data["username"] = new_username
+        self.data["email"] = "new@foo.com"
+        response = self.client.post(self.url, data=self.data)
+        self.assertTemplateUsed(response, "brasilio_auth/user_creation_form.html")
         assert bool(response.context["form"].errors) is True
 
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -44,55 +44,6 @@ def _get_name(obj, person_type):
         return obj.name
 
 
-class TracePathForm(forms.Form):
-    TYPE_CHOICES = [("pessoa-fisica", "Pessoa Física (nome completo)"), ("pessoa-juridica", "Pessoa Jurídica (CNPJ)")]
-
-    origin_type = forms.ChoiceField(choices=TYPE_CHOICES, required=True)
-    origin_identifier = forms.CharField(required=True)
-
-    destination_type = forms.ChoiceField(choices=TYPE_CHOICES, required=True)
-    destination_identifier = forms.CharField(required=True)
-
-    def clean(self):
-        cleaned_data = super().clean()
-        origin_type = cleaned_data.get("origin_type")
-        origin_identifier = cleaned_data.get("origin_identifier")
-        destination_type = cleaned_data.get("destination_type")
-        destination_identifier = cleaned_data.get("destination_identifier")
-
-        origin_field = _resolve_field_by_type(origin_type)
-        destination_field = _resolve_field_by_type(destination_type)
-        origin = _get_obj(origin_field, origin_identifier, origin_type)
-        destination = _get_obj(destination_field, destination_identifier, destination_type)
-
-        if origin is None:
-            self.add_error("origin_identifier", "Name/document not found")
-        else:
-            cleaned_data["origin_name"] = _get_name(origin, origin_type)
-        if destination is None:
-            self.add_error("destination_identifier", "Name/document not found")
-        else:
-            cleaned_data["destination_name"] = _get_name(destination, destination_type)
-
-        return cleaned_data
-
-
-class CompanyGroupsForm(forms.Form):
-    identifier = forms.CharField(required=True, label="CNPJ")
-
-    def clean(self):
-        cleaned_data = super().clean()
-        identifier = cleaned_data["identifier"]
-        for char in "./-":
-            identifier = identifier.replace(char, "")
-        company = _get_obj("", identifier, "pessoa-juridica")
-        if not company:
-            self.add_error("identifier", "Document not found")
-        else:
-            cleaned_data["company"] = company
-        return cleaned_data
-
-
 class ContactForm(forms.Form):
     name = forms.CharField(required=True, label="Nome")
     email = forms.EmailField(required=True, label="E-mail")

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -100,6 +100,7 @@ class SampleDatasetDetailView(DjangoAssertionsMixin, BaseTestCaseWithSampleDatas
     @override_settings(RATELIMIT_RATE="0/s")
     @patch("traffic_control.decorators.ratelimit")
     def test_enforce_rate_limit_if_flagged_for_api(self, mocked_ratelimit):
+        settings.ALLOWED_HOSTS.append(settings.BRASILIO_API_HOST)
         urlconf = settings.API_ROOT_URLCONF
         self.url = reverse("v1:dataset-table-data", args=["sample", "sample_table"], urlconf=urlconf)
         response = self.client.get(self.url, HTTP_HOST=settings.BRASILIO_API_HOST)

--- a/core/views_special.py
+++ b/core/views_special.py
@@ -8,7 +8,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
 from core.data_models import EmpresaTableConfig
-from core.forms import CompanyGroupsForm, TracePathForm
 from core.models import get_table, get_table_model
 
 cipher_suite = Fernet(settings.FERNET_KEY)

--- a/env.example
+++ b/env.example
@@ -6,7 +6,7 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=brasilio
 
 # Django settings
-ALLOWED_HOSTS=localhost
+ALLOWED_HOSTS=localhost,api.brasil.io
 APP_HOST="localhost:8000"
 BLOCKED_AGENTS="Wget,curl,python-requests,Python-urllib"
 DATABASE_URL=postgres://postgres:postgres@db:5432/brasilio

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,docker/postgresql/data
-ignore=I001,I003,I004,E231,E501
+ignore=I001,I003,I004,E231,E501,E203

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -202,3 +202,10 @@ a {
   color: #ee6e73;
   font-size: 1rem;
 }
+
+#id_username {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="60"><text x="5" y="29" style="font-family: Roboto, sans-serif; font-size:16px; fill:rgb(50,50,50)">@</text></svg>') no-repeat;
+  padding-left: 1.4rem !important;
+  width: 100%;
+  box-sizing: border-box !important;
+}

--- a/utils/rocketchat.py
+++ b/utils/rocketchat.py
@@ -27,7 +27,8 @@ class RocketChat:
         response = getattr(requests, method)(*args, **kwargs)
         if response.status_code >= 400:
             raise RuntimeError(
-                f"HTTP {response.status_code} error when processing request to {response.url} (body: {response.content})"
+                f"HTTP {response.status_code} error when processing request "
+                f"to {response.url} (body: {response.content})"
             )
         return response
 


### PR DESCRIPTION
Este PR está relacionado a issu #511  e implementa:
1. a validação do username no momento do Cadastro;
      - A partir de agora apenas **letras**, **número** e **_** são permitidos. Caso contrário um erro de validação de Form é levantado.
2. descrição dos erros do Form de login no template HTML.
3. atualização do script de migração de usernames com '@'.
   -  adiciona testes para as funções;
   - atualiza os registro no banco;
   - escreve um arquivo CSV no path '/data/fixed-usernames.csv' com os registros atualizados.



Para rodar o comando de atualização dos usernames:

```
python manage.py runscript migrate_wrong_usernames
```