### PR TITLE
Feature/send email

### DIFF
--- a/brasilio/settings.py
+++ b/brasilio/settings.py
@@ -242,7 +242,8 @@ CACHES = {
 }
 
 # django-rq config
-RQ_QUEUES = {"default": {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 500,}}
+DEFAULT_QUEUE_NAME = "default"
+RQ_QUEUES = {DEFAULT_QUEUE_NAME: {"URL": REDIS_URL, "DEFAULT_TIMEOUT": 500,}}
 RQ = {
     "DEFAULT_RESULT_TTL": 60 * 60 * 24,  # 24-hours
 }

--- a/brasilio/test_settings.py
+++ b/brasilio/test_settings.py
@@ -14,3 +14,4 @@ TEMPLATE_STRING_IF_INVALID = "%%%Invalid variable%%%"  # noqa
 TEMPLATES[0]["OPTIONS"]["string_if_invalid"] = TEMPLATE_STRING_IF_INVALID  # noqa
 ENABLE_API_AUTH = True
 DISABLE_RECAPTCHA = False
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/brasilio/worker.py
+++ b/brasilio/worker.py
@@ -1,8 +1,7 @@
-from rq import Worker
-from rq.contrib.sentry import register_sentry
-
 from raven import Client
 from raven.transport import HTTPTransport
+from rq import Worker
+from rq.contrib.sentry import register_sentry
 
 
 class SentryAwareWorker(Worker):

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -23,9 +23,12 @@ class Command(BaseCommand):
         for row in table:
             context = Context(row._asdict())
             rendered_template = template_obj.render(context=context)
-            send_email(
-                subject="Subject",
-                body=rendered_template,
-                from_email="from@example.com",
-                to=["to@example.com"],
-            )
+            if not kwargs["dry_run"]:
+                send_email(
+                    subject="Subject",
+                    body=rendered_template,
+                    from_email="from@example.com",
+                    to=["to@example.com"],
+                )
+            else:
+                print(rendered_template)

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -1,0 +1,31 @@
+import rows
+from django.core.management.base import BaseCommand
+from django.template import Context, Template
+
+from core.email import send_email
+
+
+class Command(BaseCommand):
+    def load_email_template(self, email_template):
+        with open(email_template, "r") as fobj:
+            return Template(fobj.read())
+
+    def add_arguments(self, parser):
+        parser.add_argument("input_filename")
+        parser.add_argument("email_template")
+        parser.add_argument("-d", "--dry-run", default=False, action="store_true")
+
+    def handle(self, *args, **kwargs):
+        input_filename = kwargs["input_filename"]
+        table = rows.import_from_csv(input_filename)
+        template_obj = self.load_email_template(kwargs["email_template"])
+
+        for row in table:
+            context = Context(row._asdict())
+            rendered_template = template_obj.render(context=context)
+            send_email(
+                subject="Subject",
+                body=rendered_template,
+                from_email="from@example.com",
+                to=["to@example.com"],
+            )

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -1,3 +1,4 @@
+import django_rq
 import rows
 from django.core.management.base import BaseCommand
 from django.template import Context, Template
@@ -24,7 +25,8 @@ class Command(BaseCommand):
             context = Context(row._asdict())
             rendered_template = template_obj.render(context=context)
             if not kwargs["dry_run"]:
-                send_email(
+                django_rq.enqueue(
+                    send_email,
                     subject="Subject",
                     body=rendered_template,
                     from_email="from@example.com",

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -43,9 +43,6 @@ class Command(BaseCommand):
                 "to": [row.to_email],
             }
             if not kwargs["dry_run"]:
-                django_rq.enqueue(
-                    send_email,
-                    **email_kwargs
-                )
+                django_rq.enqueue(send_email, **email_kwargs)
             else:
                 self.print_email_metadata(email_kwargs)

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -4,11 +4,10 @@ import rows
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template import Context, Template
-from rq import Queue
-from redis import Redis
 from tqdm import tqdm
 
 from core.email import send_email
+from core.queue import get_redis_queue
 
 
 class Command(BaseCommand):
@@ -30,8 +29,7 @@ class Command(BaseCommand):
         parser.add_argument("template_filename")
 
     def handle(self, *args, **kwargs):
-        redis_conn = Redis.from_url(settings.RQ_QUEUES[settings.DEFAULT_QUEUE_NAME]["URL"])
-        queue = Queue(name=settings.DEFAULT_QUEUE_NAME, connection=redis_conn)
+        queue = get_redis_queue(settings.DEFAULT_QUEUE_NAME, settings.RQ_QUEUES[settings.DEFAULT_QUEUE_NAME]["URL"])
 
         input_filename = kwargs["input_filename"]
         table = rows.import_from_csv(input_filename)

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -30,7 +30,8 @@ class Command(BaseCommand):
         parser.add_argument("template_filename")
 
     def handle(self, *args, **kwargs):
-        queue = Queue(name=settings.DEFAULT_QUEUE_NAME, connection=Redis())
+        redis_conn = Redis.from_url(settings.RQ_QUEUES[settings.DEFAULT_QUEUE_NAME]["URL"])
+        queue = Queue(name=settings.DEFAULT_QUEUE_NAME, connection=redis_conn)
 
         input_filename = kwargs["input_filename"]
         table = rows.import_from_csv(input_filename)

--- a/brasilio_auth/management/commands/send_bulk_emails.py
+++ b/brasilio_auth/management/commands/send_bulk_emails.py
@@ -1,5 +1,6 @@
 import django_rq
 import rows
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template import Context, Template
 
@@ -14,12 +15,17 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("input_filename")
         parser.add_argument("email_template")
+        parser.add_argument("--from")
         parser.add_argument("-d", "--dry-run", default=False, action="store_true")
 
     def handle(self, *args, **kwargs):
         input_filename = kwargs["input_filename"]
         table = rows.import_from_csv(input_filename)
+        error_msg = "Arquivo CSV deve conter campos 'to_email' e 'subject'"
+        assert {"to_email", "subject"}.issubset(set(table.field_names)), error_msg
+
         template_obj = self.load_email_template(kwargs["email_template"])
+        from_email = kwargs["from"] or settings.DEFAULT_FROM_EMAIL
 
         for row in table:
             context = Context(row._asdict())
@@ -27,10 +33,10 @@ class Command(BaseCommand):
             if not kwargs["dry_run"]:
                 django_rq.enqueue(
                     send_email,
-                    subject="Subject",
+                    subject=row.subject,
                     body=rendered_template,
-                    from_email="from@example.com",
-                    to=["to@example.com"],
+                    from_email=from_email,
+                    to=[row.to_email],
                 )
             else:
                 print(rendered_template)

--- a/brasilio_auth/tests/test_commands.py
+++ b/brasilio_auth/tests/test_commands.py
@@ -14,8 +14,7 @@ class TestSendBulkEmails(TestCase):
 
         with open(self.input_file.name, "w") as fobj:
             fobj.write(
-                "nome,data,to_email,subject\nnome_1,data_1,email_1,subject_1\n"
-                "nome_2,data_2,email_2,subject_2"
+                "nome,data,to_email,subject\nnome_1,data_1,email_1,subject_1\n" "nome_2,data_2,email_2,subject_2"
             )
 
         with open(self.email_template.name, "w") as fobj:
@@ -36,7 +35,7 @@ class TestSendBulkEmails(TestCase):
                 "subject": "subject_2",
                 "to": ["email_2"],
                 "from_email": settings.DEFAULT_FROM_EMAIL,
-            }
+            },
         ]
 
     def assert_sent_email_metadata(self, email, metadata):
@@ -52,12 +51,7 @@ class TestSendBulkEmails(TestCase):
 
     def test_send_email_custom_from_email(self):
         kwargs = {"from": "Example Email <email@example.com>"}
-        call_command(
-            "send_bulk_emails",
-            self.input_file.name,
-            self.email_template.name,
-            **kwargs
-        )
+        call_command("send_bulk_emails", self.input_file.name, self.email_template.name, **kwargs)
 
         self.expexted_send_email[0]["from_email"] = kwargs["from"]
         self.expexted_send_email[1]["from_email"] = kwargs["from"]
@@ -75,11 +69,6 @@ class TestSendBulkEmails(TestCase):
             call_command("send_bulk_emails", self.input_file.name, self.email_template.name)
 
     def test_do_not_send_mail(self):
-        call_command(
-            "send_bulk_emails",
-            self.input_file.name,
-            self.email_template.name,
-            "--dry-run"
-        )
+        call_command("send_bulk_emails", self.input_file.name, self.email_template.name, "--dry-run")
 
         assert len(mail.outbox) == 0

--- a/brasilio_auth/tests/test_commands.py
+++ b/brasilio_auth/tests/test_commands.py
@@ -38,3 +38,13 @@ class TestSendBulkEmails(TestCase):
         assert len(mail.outbox) == 2
         self.assert_sent_email_metadata(mail.outbox[0], self.expexted_send_email[0])
         self.assert_sent_email_metadata(mail.outbox[1], self.expexted_send_email[1])
+
+    def test_do_not_send_mail(self):
+        call_command(
+            "send_bulk_emails",
+            self.input_file.name,
+            self.email_template.name,
+            "--dry-run"
+        )
+
+        assert len(mail.outbox) == 0

--- a/brasilio_auth/tests/test_commands.py
+++ b/brasilio_auth/tests/test_commands.py
@@ -1,0 +1,40 @@
+from tempfile import NamedTemporaryFile
+
+from django.core import mail
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestSendBulkEmails(TestCase):
+    def setUp(self):
+        self.input_file = NamedTemporaryFile(suffix=".csv")
+        self.email_template = NamedTemporaryFile(suffix=".txt")
+
+        with open(self.input_file.name, "w") as fobj:
+            fobj.write("nome,data\nnome_1,data_1\nnome_2,data_2")
+
+        with open(self.email_template.name, "w") as fobj:
+            fobj.write("Enviado para {{ nome }} em {{ data }}")
+
+        self.input_file.seek(0)
+        self.email_template.seek(0)
+
+        self.expexted_send_email = [
+            {
+                "body": "Enviado para nome_1 em data_1",
+            },
+            {
+                "body": "Enviado para nome_2 em data_2",
+            }
+        ]
+
+    def assert_sent_email_metadata(self, email, metadata):
+        for key, value in metadata.items():
+            assert email.__getattribute__(key) == value
+
+    def test_send_bulk_emails(self):
+        call_command("send_bulk_emails", self.input_file.name, self.email_template.name)
+
+        assert len(mail.outbox) == 2
+        self.assert_sent_email_metadata(mail.outbox[0], self.expexted_send_email[0])
+        self.assert_sent_email_metadata(mail.outbox[1], self.expexted_send_email[1])

--- a/brasilio_auth/tests/test_commands.py
+++ b/brasilio_auth/tests/test_commands.py
@@ -1,5 +1,7 @@
 from tempfile import NamedTemporaryFile
 
+import pytest
+from django.conf import settings
 from django.core import mail
 from django.core.management import call_command
 from django.test import TestCase
@@ -11,7 +13,10 @@ class TestSendBulkEmails(TestCase):
         self.email_template = NamedTemporaryFile(suffix=".txt")
 
         with open(self.input_file.name, "w") as fobj:
-            fobj.write("nome,data\nnome_1,data_1\nnome_2,data_2")
+            fobj.write(
+                "nome,data,to_email,subject\nnome_1,data_1,email_1,subject_1\n"
+                "nome_2,data_2,email_2,subject_2"
+            )
 
         with open(self.email_template.name, "w") as fobj:
             fobj.write("Enviado para {{ nome }} em {{ data }}")
@@ -22,9 +27,15 @@ class TestSendBulkEmails(TestCase):
         self.expexted_send_email = [
             {
                 "body": "Enviado para nome_1 em data_1",
+                "subject": "subject_1",
+                "to": ["email_1"],
+                "from_email": settings.DEFAULT_FROM_EMAIL,
             },
             {
                 "body": "Enviado para nome_2 em data_2",
+                "subject": "subject_2",
+                "to": ["email_2"],
+                "from_email": settings.DEFAULT_FROM_EMAIL,
             }
         ]
 
@@ -38,6 +49,30 @@ class TestSendBulkEmails(TestCase):
         assert len(mail.outbox) == 2
         self.assert_sent_email_metadata(mail.outbox[0], self.expexted_send_email[0])
         self.assert_sent_email_metadata(mail.outbox[1], self.expexted_send_email[1])
+
+    def test_send_email_custom_from_email(self):
+        kwargs = {"from": "Example Email <email@example.com>"}
+        call_command(
+            "send_bulk_emails",
+            self.input_file.name,
+            self.email_template.name,
+            **kwargs
+        )
+
+        self.expexted_send_email[0]["from_email"] = kwargs["from"]
+        self.expexted_send_email[1]["from_email"] = kwargs["from"]
+
+        assert len(mail.outbox) == 2
+        self.assert_sent_email_metadata(mail.outbox[0], self.expexted_send_email[0])
+        self.assert_sent_email_metadata(mail.outbox[1], self.expexted_send_email[1])
+
+    def test_assert_mandatory_fields(self):
+        with open(self.input_file.name, "w") as fobj:
+            fobj.write("nome,data\nnome_1,data_1\nnome_2,data_2")
+
+        self.input_file.seek(0)
+        with pytest.raises(AssertionError):
+            call_command("send_bulk_emails", self.input_file.name, self.email_template.name)
 
     def test_do_not_send_mail(self):
         call_command(

--- a/core/email.py
+++ b/core/email.py
@@ -1,0 +1,12 @@
+from django.core.mail import EmailMessage
+
+
+def send_email(subject, body, from_email, to, **kwargs):
+    email = EmailMessage(
+        subject=subject,
+        body=body,
+        from_email=from_email,
+        to=to,
+        **kwargs
+    )
+    email.send()

--- a/core/email.py
+++ b/core/email.py
@@ -2,11 +2,5 @@ from django.core.mail import EmailMessage
 
 
 def send_email(subject, body, from_email, to, **kwargs):
-    email = EmailMessage(
-        subject=subject,
-        body=body,
-        from_email=from_email,
-        to=to,
-        **kwargs
-    )
+    email = EmailMessage(subject=subject, body=body, from_email=from_email, to=to, **kwargs)
     email.send()

--- a/core/queue.py
+++ b/core/queue.py
@@ -1,0 +1,7 @@
+from rq import Queue
+from redis import Redis
+
+
+def get_redis_queue(name: str, url: str) -> Queue:
+    redis_conn = Redis.from_url(url)
+    return Queue(name=name, connection=redis_conn)

--- a/core/tests/test_email.py
+++ b/core/tests/test_email.py
@@ -1,0 +1,27 @@
+from django.core import mail
+from django.test import TestCase
+
+from core.email import send_email
+
+
+class TestSendEmail(TestCase):
+    def test_send_emnail(self):
+        subject = "Subject"
+        body = "Body"
+        from_email = "from@example.com"
+        to = ["to@example.com"]
+        reply_to = ["Reply To <replyto@example.com"]
+
+        send_email(
+            subject=subject,
+            body=body,
+            from_email=from_email,
+            to=to,
+            reply_to=reply_to,
+        )
+        assert len(mail.outbox) == 1
+        assert body == mail.outbox[0].body
+        assert subject == mail.outbox[0].subject
+        assert from_email == mail.outbox[0].from_email
+        assert to == mail.outbox[0].to
+        assert reply_to == mail.outbox[0].reply_to

--- a/core/tests/test_email.py
+++ b/core/tests/test_email.py
@@ -13,11 +13,7 @@ class TestSendEmail(TestCase):
         reply_to = ["Reply To <replyto@example.com"]
 
         send_email(
-            subject=subject,
-            body=body,
-            from_email=from_email,
-            to=to,
-            reply_to=reply_to,
+            subject=subject, body=body, from_email=from_email, to=to, reply_to=reply_to,
         )
         assert len(mail.outbox) == 1
         assert body == mail.outbox[0].body

--- a/core/tests/test_queue.py
+++ b/core/tests/test_queue.py
@@ -1,0 +1,31 @@
+from unittest import mock
+
+from django.test import TestCase
+from redis import Redis
+from rq import Queue
+
+from core.queue import get_redis_queue
+
+
+class TestGetRedisQueue(TestCase):
+    def setUp(self):
+        self.m_redis_conn = mock.Mock()
+        self.p_redis_from_url = mock.patch.object(Redis, "from_url")
+        self.m_redis_from_url = self.p_redis_from_url.start()
+        self.m_redis_from_url.return_value = self.m_redis_conn
+
+        self.m_queue = mock.Mock(spec=Queue)
+        self.p_queue_cls = mock.patch("core.queue.Queue")
+        self.m_queue_cls = self.p_queue_cls.start()
+        self.m_queue_cls.return_value = self.m_queue
+
+    def tearDown(self):
+        self.p_queue_cls.stop()
+        self.m_redis_from_url.stop()
+
+    def test_get_redis_queue_with_custom_arguments(self):
+        queue = get_redis_queue(name="name", url="redis://url:6379")
+
+        assert isinstance(queue, Queue)
+        self.m_redis_from_url.assert_called_once_with("redis://url:6379")
+        self.m_queue_cls.assert_called_once_with(name="name", connection=self.m_redis_conn)

--- a/core/views.py
+++ b/core/views.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 
 from core.filters import parse_querystring
 from core.forms import ContactForm, DatasetSearchForm, get_table_dynamic_form
+from core.email import send_email
 from core.middlewares import disable_non_logged_user_cache
 from core.models import Dataset, Table
 from core.templatetags.utils import obfuscate
@@ -41,14 +42,13 @@ def contact(request):
 
         if form.is_valid():
             data = form.cleaned_data
-            email = EmailMessage(
+            send_email(
                 subject=f"Contato no Brasil.IO: {data['name']}",
                 body=data["message"],
                 from_email=f'{data["name"]} (via Brasil.IO) <{settings.DEFAULT_FROM_EMAIL}>',
                 to=[settings.DEFAULT_FROM_EMAIL],
                 reply_to=[f'{data["name"]} <{data["email"]}>'],
             )
-            email.send()
             return redirect(reverse("core:contact") + "?sent=true")
 
     else:

--- a/core/views.py
+++ b/core/views.py
@@ -3,16 +3,15 @@ import uuid
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.mail import EmailMessage
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
+from core.email import send_email
 from core.filters import parse_querystring
 from core.forms import ContactForm, DatasetSearchForm, get_table_dynamic_form
-from core.email import send_email
 from core.middlewares import disable_non_logged_user_cache
 from core.models import Dataset, Table
 from core.templatetags.utils import obfuscate

--- a/covid19/models.py
+++ b/covid19/models.py
@@ -74,8 +74,8 @@ class StateSpreadsheetQuerySet(models.QuerySet):
 class StateSpreadsheetManager(models.Manager):
     def get_state_data(self, state):
         """Return all state cases, grouped by date"""
-        from covid19.spreadsheet_validator import TOTAL_LINE_DISPLAY
         from brazil_data.cities import get_city_info
+        from covid19.spreadsheet_validator import TOTAL_LINE_DISPLAY
 
         cases, reports = defaultdict(dict), {}
         qs = self.get_queryset()

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ openpyxl==3.0.5
 psycopg2-binary==2.8.5
 pytest-django==3.2.1
 pytz==2020.1
+redis==3.5.3
 requests-cache==0.5.2
 requests==2.24.0
 retry==0.9.2


### PR DESCRIPTION
Esse PR implementa o envio de emails em batelada dado um arquivo CSV e um template TXT.
Os envios dos e-mails são colocados na fila assíncrona `default` pelo `django_rq`.

**Obs.:** Anda precisamos definir o **subject**, **to** (teremos um campo email no csv?) e **from_email** do email enviado.

Para rodar o comanda basta executar:

```
python manage.py send_bulk_emails input_filename.csv email_template.txt
```
Existe também uma opção que apenas imprime os emails na tela, com a flag `--dry-run`:
```
python manage.py send_bulk_emails input_filename.csv email_template.txt  --dry-run
```