### PR TITLE
Pre-commit hook atualização de configurações

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,42 @@
-exclude: 'docs|node_modules|.git|.tox'
-default_stages: [commit]
-fail_fast: true
+exclude: '.git|.tox|migrations|brasilio/wsgi.py|docker'
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: master
+    rev: v3.4.0
     hooks:
       - id: trailing-whitespace
         files: (^|/).+\.(py|html|sh|css|js)$
 
--   repo: local
-    hooks:
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: python
-        types: [python]
-        args: ['--config=setup.cfg']
-      - id: black
-        name: black
-        entry: black .
-        language: python
-        types: [python]
-        args: ['--check', '-l', '120', '--exclude', 'docker']
+- repo: local
+  hooks:
+    - id: autoflake
+      name: autoflake
+      entry: autoflake
+      language: python
+      types: 
+        - python
+      args: [--in-place, --recursive, --remove-unused-variables, --remove-all-unused-imports]
+      
+    - id: isort
+      name: "format imports with isort"
+      entry: isort
+      language: python
+      types:
+        - python
+      args: [--line-length=120]
+
+    - id: black
+      name: "format code with black"
+      entry: black
+      language: python
+      types:
+        - python
+      args: [--line-length=120]
+    
+    - id: flake8
+      name: "lint code with flake8"
+      entry: flake8
+      language: python
+      types:
+        - python
+      args: [--config=setup.cfg]

--- a/docs/dev-process.md
+++ b/docs/dev-process.md
@@ -24,6 +24,13 @@ make run
 
 Nosso arquivo [Makefile](https://github.com/turicas/brasil.io/blob/develop/Makefile) possui outras entradas que podem te ser úteis durante o processo de desenvolvimento.
 
+### Utilizar Pre-commit hooks
+Com o pre-commit hooks toda vez que um novo commit for feito durante o desenvolvimento será verificado se o código commitado está no formato ideal. Caso não esteja, será automaticamente corrigido gerando uma modificação com as correções. Para ativá-lo o comando é:
+
+```
+pre-commit install
+```
+
 ### Padrões de arquivos de apps
 
 O projeto segue alguns padrões de organização dos arquivos das apps Django. Mais especificamente em relação aos arquivos estáticos, templates e de testes.

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -3,8 +3,9 @@
 autoflake==1.3.1
 black==19.10b0
 flake8==3.7.9
-isort==4.3.21
+isort==5.8.0
 model-bakery==1.1.0
 pytest-django==3.2.1
 pytest-env==0.6.2
 pytest==4.4.1
+pre-commit==2.12.0


### PR DESCRIPTION
Adicionado uma atualização de configurações para uso de pre-commit durante desenvolvimento.

Com a adição do pre-commit ao `requirements-development.txt`, após a instalação das dependências, é necessário apenas usar o comando :
```
pre-commit install
```
Para que as configurações do arquivo yaml sejam passadas para a pasta `.git/hooks/pre-commit`