### PR TITLE
Remove css que força username para lowercase

### DIFF
--- a/brasilio_auth/forms.py
+++ b/brasilio_auth/forms.py
@@ -17,7 +17,7 @@ def is_valid_username(username):
 
 
 class UserCreationForm(RegistrationFormUniqueEmail):
-    username = forms.CharField(widget=forms.TextInput(attrs={"style": "text-transform: lowercase"}),)
+    username = forms.CharField(widget=forms.TextInput(),)
     email = forms.EmailField()
     password1 = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
     password2 = forms.CharField(


### PR DESCRIPTION
Remove o trecho do código que forçava o username para lowercase no momento do SignUp.

Entretanto, a validação do username continua sendo feita com `iexact` tanto no SignUp (para não haver repetição), quanto no login (o usuário consegue logar variando o case do mesmo username)

- [Validação no SignUp](https://github.com/turicas/brasil.io/blob/9ec3264ef8a72c0a3f03e2b5c210bb4ce2bbfc5b/brasilio_auth/forms.py#L41)
- [Validação no login](https://github.com/turicas/brasil.io/blob/9ec3264ef8a72c0a3f03e2b5c210bb4ce2bbfc5b/brasilio_auth/auth_backend.py#L15)